### PR TITLE
feat: add MessageType and Message to CoveyTypes

### DIFF
--- a/services/roomService/src/CoveyTypes.ts
+++ b/services/roomService/src/CoveyTypes.ts
@@ -16,9 +16,11 @@ export enum MessageType {
 };
 
 export type Message = {
+  // user who sent the message
   user: Player;
   messageContent: string;
   timestamp: string;
   type: MessageType;
+  // null for cases of Proximity and Town Message
   directMessageId: string | null;
 }

--- a/services/roomService/src/CoveyTypes.ts
+++ b/services/roomService/src/CoveyTypes.ts
@@ -22,5 +22,5 @@ export type Message = {
   timestamp: string;
   type: MessageType;
   // null for cases of Proximity and Town Message
-  directMessageId: string | null;
+  directMessageId: string | undefined;
 }

--- a/services/roomService/src/CoveyTypes.ts
+++ b/services/roomService/src/CoveyTypes.ts
@@ -1,3 +1,5 @@
+import Player from "./types/Player";
+
 export type Direction = 'front' | 'back' | 'left' | 'right';
 export type UserLocation = {
   x: number;
@@ -7,3 +9,16 @@ export type UserLocation = {
 };
 export type CoveyTownList = { friendlyName: string; coveyTownID: string; currentOccupancy: number; maximumOccupancy: number }[];
 
+export enum MessageType {
+  DirectMessage,
+  ProximityMessage,
+  TownMessage
+};
+
+export type Message = {
+  user: Player;
+  messageContent: string;
+  timestamp: string;
+  type: MessageType;
+  directMessageId: string | null;
+}


### PR DESCRIPTION
Adds the types : enum MessageType and type Message to the backend based on project plan specification

No tests added for types