### PR TITLE
Anika/message chain

### DIFF
--- a/services/roomService/src/types/MessageChain.test.ts
+++ b/services/roomService/src/types/MessageChain.test.ts
@@ -1,0 +1,99 @@
+import { nanoid } from 'nanoid';
+import { Message, MessageType } from "../CoveyTypes";
+import MessageChain from "./MessageChain";
+import Player from "./Player";
+
+function createPlayerForTesting(){
+    return new Player('player 1');
+}
+
+function createMessageForTesting(type: MessageType, player1: Player, player2id?: string) {
+    const timestamp = Date.now().toString();
+    let directMessageID = undefined;
+    if (player2id) {
+        directMessageID = player1.id + ':' + player2id;
+    }
+    return {
+        user: player1,
+        messageContent: 'Omg I\'m a test',
+        timestamp: timestamp,
+        type: type,
+        directMessageId: directMessageID,
+    }
+}
+
+function createMessageChainForTesting(startingMessage: Message): MessageChain {
+    return new MessageChain(startingMessage);
+}
+
+describe('MessageChain', () => {
+    it('get messages', () => {
+        const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
+        const testChain = createMessageChainForTesting(firstMessage);
+        expect(firstMessage).toBe(testChain.messages[0]);
+    });
+    it('get isActive', () => {
+        const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
+        const testChain = createMessageChainForTesting(firstMessage);
+        expect(testChain.isActive).toBe(true);
+    });
+    it('set isActive', () => {
+        const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
+        const testChain = createMessageChainForTesting(firstMessage);
+        expect(testChain.isActive).toBe(true);
+        testChain.updateIsActive(false);
+        expect(testChain.isActive).toBe(false);
+    });
+    describe('get directMessageId', () => {
+        it('should return undefined for MessageChain that is not direct', () => {
+            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
+            const testChain = createMessageChainForTesting(firstMessage);
+            expect(testChain.directMessageId).toBeUndefined();
+        });
+        it('should return a string id for a MessageChain containing DirectMessages', () => {
+            const player1 = createPlayerForTesting();
+            const player2id = nanoid();
+            const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1, player2id);
+            const testChain = createMessageChainForTesting(firstMessage);
+            expect(testChain.directMessageId).toBe(firstMessage.directMessageId);
+            expect(testChain.directMessageId).toBe(player1.id + ':' + player2id);
+        });
+    })
+    describe('get participants', () => {
+        it('should return undefined for MessageChain that is not direct', () => {
+            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
+            const testChain = createMessageChainForTesting(firstMessage);
+            expect(testChain.participants).toBeUndefined();
+        });
+        it('should return a string array for a MessageChain containing DirectMessages', () => {
+            const player1 = createPlayerForTesting();
+            const player2id = nanoid();
+            const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1, player2id);
+            const testChain = createMessageChainForTesting(firstMessage);
+            expect(testChain.participants?.length).toBe(2);
+        });
+    })
+    describe('addMessage', () => {
+        it('should allow for message added to active MessageChain', () => {
+            const player1 = createPlayerForTesting();
+            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+            const testChain = createMessageChainForTesting(firstMessage);
+            expect(testChain.messages.length).toBe(1);
+            const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+            expect(testChain.addMessage(secondMessage)).toBe(false);
+            expect(testChain.messages.length).toBe(2);
+            expect(secondMessage).toBe(testChain.messages[1]);
+        });
+        it('should not allow message to add to inactive chain', () => {
+            const player1 = createPlayerForTesting();
+            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+            const testChain = createMessageChainForTesting(firstMessage);
+            expect(testChain.messages.length).toBe(1);
+            testChain.updateIsActive(false);
+            const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+            expect(testChain.addMessage(secondMessage)).toBe(false);
+            expect(testChain.messages.length).toBe(1);
+        });
+    })
+
+})

--- a/services/roomService/src/types/MessageChain.test.ts
+++ b/services/roomService/src/types/MessageChain.test.ts
@@ -41,7 +41,7 @@ describe('MessageChain', () => {
         const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
         const testChain = createMessageChainForTesting(firstMessage);
         expect(testChain.isActive).toBe(true);
-        testChain.updateIsActive(false);
+        testChain.isActive = false;
         expect(testChain.isActive).toBe(false);
     });
     describe('get directMessageId', () => {
@@ -89,7 +89,7 @@ describe('MessageChain', () => {
             const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
             const testChain = createMessageChainForTesting(firstMessage);
             expect(testChain.messages.length).toBe(1);
-            testChain.updateIsActive(false);
+            testChain.isActive = false;
             const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
             expect(testChain.addMessage(secondMessage)).toBe(false);
             expect(testChain.messages.length).toBe(1);

--- a/services/roomService/src/types/MessageChain.test.ts
+++ b/services/roomService/src/types/MessageChain.test.ts
@@ -80,7 +80,7 @@ describe('MessageChain', () => {
             const testChain = createMessageChainForTesting(firstMessage);
             expect(testChain.messages.length).toBe(1);
             const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
-            expect(testChain.addMessage(secondMessage)).toBe(false);
+            expect(testChain.addMessage(secondMessage)).toBe(true);
             expect(testChain.messages.length).toBe(2);
             expect(secondMessage).toBe(testChain.messages[1]);
         });

--- a/services/roomService/src/types/MessageChain.ts
+++ b/services/roomService/src/types/MessageChain.ts
@@ -27,14 +27,34 @@ export default class MessageChain {
     get messages(): Message[] {
         return this._messages;
     }
+
     get isActive(): boolean {
         return this._isActive;
     }
+
     get directMessageId(): string | undefined {
         return this._directMessageId;
     }
+
     get participants(): string[] | undefined {
         return this._participants;
+    }
+
+    set isActive(value: boolean) {
+        this._isActive = value;
+    }
+
+    /**
+     * Adds new message to this message chain
+     * @param newMessage The new message to add to this chain
+     */
+    addMessage(newMessage: Message): void {
+        if (this._isActive == true) {
+            this._messages.push(newMessage);
+        }
+        else {
+            throw new Error(`Message could not be sent, this chat is inactive.`);
+        }
     }
 
 }

--- a/services/roomService/src/types/MessageChain.ts
+++ b/services/roomService/src/types/MessageChain.ts
@@ -6,6 +6,7 @@ import { Message, MessageType } from "../CoveyTypes";
 export default class MessageChain {
     private _messages: Message[] = [];
     private _isActive: boolean;
+    // only needed for MessageChains containing messages of the DirectMessage type
     private readonly _directMessageId: string | undefined;
     private readonly _participants: string[] | undefined;
     
@@ -40,21 +41,21 @@ export default class MessageChain {
         return this._participants;
     }
 
-    set isActive(value: boolean) {
+    updateIsActive(value: boolean) {
         this._isActive = value;
     }
 
     /**
-     * Adds new message to this message chain
+     * Adds new message to this message chain. Return true if message was added, 
+     * false if this chain is inactive.
      * @param newMessage The new message to add to this chain
      */
-    addMessage(newMessage: Message): void {
+    addMessage(newMessage: Message): boolean {
         if (this._isActive == true) {
             this._messages.push(newMessage);
+            return true;
         }
-        else {
-            throw new Error(`Message could not be sent, this chat is inactive.`);
-        }
+        return false;
     }
 
 }

--- a/services/roomService/src/types/MessageChain.ts
+++ b/services/roomService/src/types/MessageChain.ts
@@ -41,7 +41,7 @@ export default class MessageChain {
         return this._participants;
     }
 
-    updateIsActive(value: boolean) {
+    set isActive(value: boolean) {
         this._isActive = value;
     }
 

--- a/services/roomService/src/types/MessageChain.ts
+++ b/services/roomService/src/types/MessageChain.ts
@@ -1,0 +1,40 @@
+import { Message, MessageType } from "../CoveyTypes";
+
+/**
+ * Each set of messages that a player has is represented by a MessageChain
+ */
+export default class MessageChain {
+    private _messages: Message[] = [];
+    private _isActive: boolean;
+    private readonly _directMessageId: string | undefined;
+    private readonly _participants: string[] | undefined;
+    
+    constructor(message : Message) {
+        this._isActive = true;
+        this._messages.push(message);
+        if (message.type == MessageType.DirectMessage) {
+            this._directMessageId = message.directMessageId;
+            
+            // split directMessageID into two player IDs
+            this._participants = message.directMessageId?.split(':');
+        }
+        else {
+            this._directMessageId = undefined;
+            this._participants = undefined;
+        }
+    }
+
+    get messages(): Message[] {
+        return this._messages;
+    }
+    get isActive(): boolean {
+        return this._isActive;
+    }
+    get directMessageId(): string | undefined {
+        return this._directMessageId;
+    }
+    get participants(): string[] | undefined {
+        return this._participants;
+    }
+
+}


### PR DESCRIPTION
Implements MessageChain class and tests.
- includes functions to update isActive and addMessage()
- addMessage only checks whether the chain isActive before adding- the Player would handle deciding which chain to call addMessage on. If we think it's necessary I can go back and add checks for correct directMessageID, but we won't be able to check whether proximity vs global is right chain
- one Q: why were we needing participants list again? i included it from the design but I was unsure