### PR TITLE
added chat select tabs

### DIFF
--- a/frontend/src/components/Chat/ChatSelectContainer.tsx
+++ b/frontend/src/components/Chat/ChatSelectContainer.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import ChatSelectTabs from './ChatSelectTabs';
 
 export default function ChatSelectContainer(): JSX.Element {
-  return <div />;
+  return <div>
+    <ChatSelectTabs/>
+  </div>;
 }

--- a/frontend/src/components/Chat/ChatSelectTabs.tsx
+++ b/frontend/src/components/Chat/ChatSelectTabs.tsx
@@ -1,0 +1,26 @@
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+import React from 'react';
+
+export default function ChatSelectContainer(): JSX.Element {
+  return (
+    <Tabs isFitted variant='enclosed' defaultIndex={0}>
+      <TabList mb='1em'>
+        <Tab>Direct Messages</Tab>
+        <Tab>Town Messages</Tab>
+        <Tab>Proximity Messages</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <p>Direct Messages:</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Town Messages:</p>
+        </TabPanel>
+        <TabPanel>
+          <p>Proximty Messages:</p>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+}
+

--- a/frontend/src/components/Chat/ChatSelectTabs.tsx
+++ b/frontend/src/components/Chat/ChatSelectTabs.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 
 export default function ChatSelectContainer(): JSX.Element {
   return (
-    <Tabs isFitted variant='enclosed' defaultIndex={0}>
+    <Tabs isFitted variant='enclosed' defaultIndex={0} size="md">
       <TabList mb='1em'>
-        <Tab>Direct Messages</Tab>
-        <Tab>Town Messages</Tab>
-        <Tab>Proximity Messages</Tab>
+        <Tab>Direct Chat</Tab>
+        <Tab>Town Chat</Tab>
+        <Tab>Proximity Chat</Tab>
       </TabList>
       <TabPanels>
         <TabPanel>
@@ -17,7 +17,7 @@ export default function ChatSelectContainer(): JSX.Element {
           <p>Town Messages:</p>
         </TabPanel>
         <TabPanel>
-          <p>Proximty Messages:</p>
+          <p>Proximity Messages:</p>
         </TabPanel>
       </TabPanels>
     </Tabs>


### PR DESCRIPTION
- Created new Chat Select Tabs component
- Added component to ChatSelect Container
- default tab selected is direct messages

No real functionality to be tested besides the tab switching to different views. In a later PR, on tab switch the correct component for each chat will be rendered. For now I just put some placeholder text which can be removed later. 

![Screen Shot 2021-03-20 at 2 09 22 PM](https://user-images.githubusercontent.com/32179812/111881239-f6405900-8985-11eb-91d7-94f6de3903be.png)
