### PR TITLE
Implemented town-wide chat in Player

### DIFF
--- a/services/roomService/src/CoveyTypes.ts
+++ b/services/roomService/src/CoveyTypes.ts
@@ -10,14 +10,14 @@ export type CoveyTownList = { friendlyName: string; coveyTownID: string; current
 export enum MessageType {
   DirectMessage,
   ProximityMessage,
-  TownMessage
-};
+  TownMessage,
+}
 
 export type PlayerData = {
   location: UserLocation;
   userName: string;
   id: string;
-}
+};
 
 export type Message = {
   // user who sent the message
@@ -27,4 +27,4 @@ export type Message = {
   type: MessageType;
   // null for cases of Proximity and Town Message
   directMessageId: string | undefined;
-}
+};

--- a/services/roomService/src/CoveyTypes.ts
+++ b/services/roomService/src/CoveyTypes.ts
@@ -1,5 +1,3 @@
-import Player from "./types/Player";
-
 export type Direction = 'front' | 'back' | 'left' | 'right';
 export type UserLocation = {
   x: number;
@@ -15,9 +13,15 @@ export enum MessageType {
   TownMessage
 };
 
+export type PlayerData = {
+  location: UserLocation;
+  userName: string;
+  id: string;
+}
+
 export type Message = {
   // user who sent the message
-  user: Player;
+  user: PlayerData;
   messageContent: string;
   timestamp: string;
   type: MessageType;

--- a/services/roomService/src/TestUtils.ts
+++ b/services/roomService/src/TestUtils.ts
@@ -1,26 +1,26 @@
-import { MessageType, Message } from "./CoveyTypes";
-import MessageChain from "./types/MessageChain";
-import Player from "./types/Player";
+import { Message, MessageType } from './CoveyTypes';
+import MessageChain from './types/MessageChain';
+import Player from './types/Player';
 
-export function createPlayerForTesting(){
-    return new Player('player 1');
+export function createPlayerForTesting() {
+  return new Player('player 1');
 }
 
 export function createMessageForTesting(type: MessageType, player1: Player, player2id?: string) {
-    const timestamp = Date.now().toString();
-    let directMessageID = undefined;
-    if (player2id) {
-        directMessageID = player1.id + ':' + player2id;
-    }
-    return {
-        user: player1,
-        messageContent: 'Omg I\'m a test',
-        timestamp: timestamp,
-        type: type,
-        directMessageId: directMessageID,
-    }
+  const timestamp = Date.now().toString();
+  let directMessageID = undefined;
+  if (player2id) {
+    directMessageID = player1.id + ':' + player2id;
+  }
+  return {
+    user: player1,
+    messageContent: "Omg I'm a test",
+    timestamp: timestamp,
+    type: type,
+    directMessageId: directMessageID,
+  };
 }
 
 export function createMessageChainForTesting(startingMessage: Message): MessageChain {
-    return new MessageChain(startingMessage);
+  return new MessageChain(startingMessage);
 }

--- a/services/roomService/src/TestUtils.ts
+++ b/services/roomService/src/TestUtils.ts
@@ -13,7 +13,7 @@ export function createMessageForTesting(type: MessageType, player1: Player, play
     directMessageID = player1.id + ':' + player2id;
   }
   return {
-    user: player1,
+    user: {location: player1.location, userName: player1.userName, id: player1.id},
     messageContent: "Omg I'm a test",
     timestamp: timestamp,
     type: type,

--- a/services/roomService/src/TestUtils.ts
+++ b/services/roomService/src/TestUtils.ts
@@ -1,0 +1,26 @@
+import { MessageType, Message } from "./CoveyTypes";
+import MessageChain from "./types/MessageChain";
+import Player from "./types/Player";
+
+export function createPlayerForTesting(){
+    return new Player('player 1');
+}
+
+export function createMessageForTesting(type: MessageType, player1: Player, player2id?: string) {
+    const timestamp = Date.now().toString();
+    let directMessageID = undefined;
+    if (player2id) {
+        directMessageID = player1.id + ':' + player2id;
+    }
+    return {
+        user: player1,
+        messageContent: 'Omg I\'m a test',
+        timestamp: timestamp,
+        type: type,
+        directMessageId: directMessageID,
+    }
+}
+
+export function createMessageChainForTesting(startingMessage: Message): MessageChain {
+    return new MessageChain(startingMessage);
+}

--- a/services/roomService/src/TestUtils.ts
+++ b/services/roomService/src/TestUtils.ts
@@ -2,21 +2,21 @@ import { Message, MessageType } from './CoveyTypes';
 import MessageChain from './types/MessageChain';
 import Player from './types/Player';
 
-export function createPlayerForTesting() {
+export function createPlayerForTesting(): Player {
   return new Player('player 1');
 }
 
-export function createMessageForTesting(type: MessageType, player1: Player, player2id?: string) {
+export function createMessageForTesting(type: MessageType, player1: Player, player2id?: string): Message {
   const timestamp = Date.now().toString();
-  let directMessageID = undefined;
+  let directMessageID;
   if (player2id) {
-    directMessageID = player1.id + ':' + player2id;
+    directMessageID = `${player1.id}:${player2id}`;
   }
   return {
     user: {location: player1.location, userName: player1.userName, id: player1.id},
     messageContent: "Omg I'm a test",
-    timestamp: timestamp,
-    type: type,
+    timestamp,
+    type,
     directMessageId: directMessageID,
   };
 }

--- a/services/roomService/src/types/MessageChain.test.ts
+++ b/services/roomService/src/types/MessageChain.test.ts
@@ -1,30 +1,9 @@
 import { nanoid } from 'nanoid';
 import { Message, MessageType } from "../CoveyTypes";
+import { createMessageForTesting, createMessageChainForTesting, createPlayerForTesting } from '../TestUtils';
 import MessageChain from "./MessageChain";
 import Player from "./Player";
 
-function createPlayerForTesting(){
-    return new Player('player 1');
-}
-
-function createMessageForTesting(type: MessageType, player1: Player, player2id?: string) {
-    const timestamp = Date.now().toString();
-    let directMessageID = undefined;
-    if (player2id) {
-        directMessageID = player1.id + ':' + player2id;
-    }
-    return {
-        user: player1,
-        messageContent: 'Omg I\'m a test',
-        timestamp: timestamp,
-        type: type,
-        directMessageId: directMessageID,
-    }
-}
-
-function createMessageChainForTesting(startingMessage: Message): MessageChain {
-    return new MessageChain(startingMessage);
-}
 
 describe('MessageChain', () => {
     it('get messages', () => {

--- a/services/roomService/src/types/MessageChain.test.ts
+++ b/services/roomService/src/types/MessageChain.test.ts
@@ -49,7 +49,7 @@ describe('MessageChain', () => {
       const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1, player2id);
       const testChain = createMessageChainForTesting(firstMessage);
       expect(testChain.directMessageId).toBe(firstMessage.directMessageId);
-      expect(testChain.directMessageId).toBe(player1.id + ':' + player2id);
+      expect(testChain.directMessageId).toBe(`${player1.id}:${player2id}`);
     });
   });
   describe('get participants', () => {

--- a/services/roomService/src/types/MessageChain.test.ts
+++ b/services/roomService/src/types/MessageChain.test.ts
@@ -1,78 +1,94 @@
 import { nanoid } from 'nanoid';
-import { Message, MessageType } from "../CoveyTypes";
-import { createMessageForTesting, createMessageChainForTesting, createPlayerForTesting } from '../TestUtils';
-import MessageChain from "./MessageChain";
-import Player from "./Player";
-
+import { MessageType } from '../CoveyTypes';
+import {
+  createMessageChainForTesting,
+  createMessageForTesting,
+  createPlayerForTesting,
+} from '../TestUtils';
+import Player from './Player';
 
 describe('MessageChain', () => {
-    it('get messages', () => {
-        const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
-        const testChain = createMessageChainForTesting(firstMessage);
-        expect(firstMessage).toBe(testChain.messages[0]);
+  it('get messages', () => {
+    const firstMessage = createMessageForTesting(
+      MessageType.ProximityMessage,
+      new Player('player 1'),
+    );
+    const testChain = createMessageChainForTesting(firstMessage);
+    expect(firstMessage).toBe(testChain.messages[0]);
+  });
+  it('get isActive', () => {
+    const firstMessage = createMessageForTesting(
+      MessageType.ProximityMessage,
+      new Player('player 1'),
+    );
+    const testChain = createMessageChainForTesting(firstMessage);
+    expect(testChain.isActive).toBe(true);
+  });
+  it('set isActive', () => {
+    const firstMessage = createMessageForTesting(
+      MessageType.ProximityMessage,
+      new Player('player 1'),
+    );
+    const testChain = createMessageChainForTesting(firstMessage);
+    expect(testChain.isActive).toBe(true);
+    testChain.isActive = false;
+    expect(testChain.isActive).toBe(false);
+  });
+  describe('get directMessageId', () => {
+    it('should return undefined for MessageChain that is not direct', () => {
+      const firstMessage = createMessageForTesting(
+        MessageType.ProximityMessage,
+        new Player('player 1'),
+      );
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.directMessageId).toBeUndefined();
     });
-    it('get isActive', () => {
-        const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
-        const testChain = createMessageChainForTesting(firstMessage);
-        expect(testChain.isActive).toBe(true);
+    it('should return a string id for a MessageChain containing DirectMessages', () => {
+      const player1 = createPlayerForTesting();
+      const player2id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1, player2id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.directMessageId).toBe(firstMessage.directMessageId);
+      expect(testChain.directMessageId).toBe(player1.id + ':' + player2id);
     });
-    it('set isActive', () => {
-        const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
-        const testChain = createMessageChainForTesting(firstMessage);
-        expect(testChain.isActive).toBe(true);
-        testChain.isActive = false;
-        expect(testChain.isActive).toBe(false);
+  });
+  describe('get participants', () => {
+    it('should return undefined for MessageChain that is not direct', () => {
+      const firstMessage = createMessageForTesting(
+        MessageType.ProximityMessage,
+        new Player('player 1'),
+      );
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.participants).toBeUndefined();
     });
-    describe('get directMessageId', () => {
-        it('should return undefined for MessageChain that is not direct', () => {
-            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
-            const testChain = createMessageChainForTesting(firstMessage);
-            expect(testChain.directMessageId).toBeUndefined();
-        });
-        it('should return a string id for a MessageChain containing DirectMessages', () => {
-            const player1 = createPlayerForTesting();
-            const player2id = nanoid();
-            const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1, player2id);
-            const testChain = createMessageChainForTesting(firstMessage);
-            expect(testChain.directMessageId).toBe(firstMessage.directMessageId);
-            expect(testChain.directMessageId).toBe(player1.id + ':' + player2id);
-        });
-    })
-    describe('get participants', () => {
-        it('should return undefined for MessageChain that is not direct', () => {
-            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, new Player('player 1'));
-            const testChain = createMessageChainForTesting(firstMessage);
-            expect(testChain.participants).toBeUndefined();
-        });
-        it('should return a string array for a MessageChain containing DirectMessages', () => {
-            const player1 = createPlayerForTesting();
-            const player2id = nanoid();
-            const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1, player2id);
-            const testChain = createMessageChainForTesting(firstMessage);
-            expect(testChain.participants?.length).toBe(2);
-        });
-    })
-    describe('addMessage', () => {
-        it('should allow for message added to active MessageChain', () => {
-            const player1 = createPlayerForTesting();
-            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
-            const testChain = createMessageChainForTesting(firstMessage);
-            expect(testChain.messages.length).toBe(1);
-            const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
-            expect(testChain.addMessage(secondMessage)).toBe(true);
-            expect(testChain.messages.length).toBe(2);
-            expect(secondMessage).toBe(testChain.messages[1]);
-        });
-        it('should not allow message to add to inactive chain', () => {
-            const player1 = createPlayerForTesting();
-            const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
-            const testChain = createMessageChainForTesting(firstMessage);
-            expect(testChain.messages.length).toBe(1);
-            testChain.isActive = false;
-            const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
-            expect(testChain.addMessage(secondMessage)).toBe(false);
-            expect(testChain.messages.length).toBe(1);
-        });
-    })
-
-})
+    it('should return a string array for a MessageChain containing DirectMessages', () => {
+      const player1 = createPlayerForTesting();
+      const player2id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1, player2id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.participants?.length).toBe(2);
+    });
+  });
+  describe('addMessage', () => {
+    it('should allow for message added to active MessageChain', () => {
+      const player1 = createPlayerForTesting();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+      expect(testChain.addMessage(secondMessage)).toBe(true);
+      expect(testChain.messages.length).toBe(2);
+      expect(secondMessage).toBe(testChain.messages[1]);
+    });
+    it('should not allow message to add to inactive chain', () => {
+      const player1 = createPlayerForTesting();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      testChain.isActive = false;
+      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1);
+      expect(testChain.addMessage(secondMessage)).toBe(false);
+      expect(testChain.messages.length).toBe(1);
+    });
+  });
+});

--- a/services/roomService/src/types/MessageChain.ts
+++ b/services/roomService/src/types/MessageChain.ts
@@ -10,16 +10,17 @@ export default class MessageChain {
     private readonly _directMessageId: string | undefined;
     private readonly _participants: string[] | undefined;
     
-    constructor(message : Message) {
+    constructor(message?: Message) {
         this._isActive = true;
-        this._messages.push(message);
-        if (message.type == MessageType.DirectMessage) {
-            this._directMessageId = message.directMessageId;
-            
-            // split directMessageID into two player IDs
-            this._participants = message.directMessageId?.split(':');
-        }
-        else {
+        if (message !== undefined) { // message will only be passed in when starting a direct message chain
+            this._messages.push(message);
+            if (message.type == MessageType.DirectMessage) {
+                this._directMessageId = message.directMessageId;
+                
+                // split directMessageID into two player IDs
+                this._participants = message.directMessageId?.split(':');
+            }
+        } else {
             this._directMessageId = undefined;
             this._participants = undefined;
         }

--- a/services/roomService/src/types/MessageChain.ts
+++ b/services/roomService/src/types/MessageChain.ts
@@ -4,10 +4,14 @@ import { Message, MessageType } from '../CoveyTypes';
  * Each set of messages that a player has is represented by a MessageChain
  */
 export default class MessageChain {
+
   private _messages: Message[] = [];
+
   private _isActive: boolean;
+
   // only needed for MessageChains containing messages of the DirectMessage type
   private readonly _directMessageId: string | undefined;
+
   private readonly _participants: string[] | undefined;
 
   constructor(message?: Message) {
@@ -15,7 +19,7 @@ export default class MessageChain {
     if (message !== undefined) {
       // message will only be passed in when starting a direct message chain
       this._messages.push(message);
-      if (message.type == MessageType.DirectMessage) {
+      if (message.type === MessageType.DirectMessage) {
         this._directMessageId = message.directMessageId;
 
         // split directMessageID into two player IDs
@@ -35,6 +39,10 @@ export default class MessageChain {
     return this._isActive;
   }
 
+  set isActive(value: boolean) {
+    this._isActive = value;
+  }
+
   get directMessageId(): string | undefined {
     return this._directMessageId;
   }
@@ -43,17 +51,13 @@ export default class MessageChain {
     return this._participants;
   }
 
-  set isActive(value: boolean) {
-    this._isActive = value;
-  }
-
   /**
    * Adds new message to this message chain. Return true if message was added,
    * false if this chain is inactive.
    * @param newMessage The new message to add to this chain
    */
   addMessage(newMessage: Message): boolean {
-    if (this._isActive == true) {
+    if (this._isActive) {
       this._messages.push(newMessage);
       return true;
     }

--- a/services/roomService/src/types/MessageChain.ts
+++ b/services/roomService/src/types/MessageChain.ts
@@ -1,62 +1,62 @@
-import { Message, MessageType } from "../CoveyTypes";
+import { Message, MessageType } from '../CoveyTypes';
 
 /**
  * Each set of messages that a player has is represented by a MessageChain
  */
 export default class MessageChain {
-    private _messages: Message[] = [];
-    private _isActive: boolean;
-    // only needed for MessageChains containing messages of the DirectMessage type
-    private readonly _directMessageId: string | undefined;
-    private readonly _participants: string[] | undefined;
-    
-    constructor(message?: Message) {
-        this._isActive = true;
-        if (message !== undefined) { // message will only be passed in when starting a direct message chain
-            this._messages.push(message);
-            if (message.type == MessageType.DirectMessage) {
-                this._directMessageId = message.directMessageId;
-                
-                // split directMessageID into two player IDs
-                this._participants = message.directMessageId?.split(':');
-            }
-        } else {
-            this._directMessageId = undefined;
-            this._participants = undefined;
-        }
-    }
+  private _messages: Message[] = [];
+  private _isActive: boolean;
+  // only needed for MessageChains containing messages of the DirectMessage type
+  private readonly _directMessageId: string | undefined;
+  private readonly _participants: string[] | undefined;
 
-    get messages(): Message[] {
-        return this._messages;
-    }
+  constructor(message?: Message) {
+    this._isActive = true;
+    if (message !== undefined) {
+      // message will only be passed in when starting a direct message chain
+      this._messages.push(message);
+      if (message.type == MessageType.DirectMessage) {
+        this._directMessageId = message.directMessageId;
 
-    get isActive(): boolean {
-        return this._isActive;
+        // split directMessageID into two player IDs
+        this._participants = message.directMessageId?.split(':');
+      }
+    } else {
+      this._directMessageId = undefined;
+      this._participants = undefined;
     }
+  }
 
-    get directMessageId(): string | undefined {
-        return this._directMessageId;
+  get messages(): Message[] {
+    return this._messages;
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  get directMessageId(): string | undefined {
+    return this._directMessageId;
+  }
+
+  get participants(): string[] | undefined {
+    return this._participants;
+  }
+
+  set isActive(value: boolean) {
+    this._isActive = value;
+  }
+
+  /**
+   * Adds new message to this message chain. Return true if message was added,
+   * false if this chain is inactive.
+   * @param newMessage The new message to add to this chain
+   */
+  addMessage(newMessage: Message): boolean {
+    if (this._isActive == true) {
+      this._messages.push(newMessage);
+      return true;
     }
-
-    get participants(): string[] | undefined {
-        return this._participants;
-    }
-
-    set isActive(value: boolean) {
-        this._isActive = value;
-    }
-
-    /**
-     * Adds new message to this message chain. Return true if message was added, 
-     * false if this chain is inactive.
-     * @param newMessage The new message to add to this chain
-     */
-    addMessage(newMessage: Message): boolean {
-        if (this._isActive == true) {
-            this._messages.push(newMessage);
-            return true;
-        }
-        return false;
-    }
-
+    return false;
+  }
 }

--- a/services/roomService/src/types/Player.test.ts
+++ b/services/roomService/src/types/Player.test.ts
@@ -1,26 +1,26 @@
 import { MessageType } from '../CoveyTypes';
-import { createMessageForTesting, createMessageChainForTesting, createPlayerForTesting } from '../TestUtils';
+import { createMessageForTesting, createPlayerForTesting } from '../TestUtils';
 
 describe('Player', () => {
-    it('has an empty town message chain upon initialization', () => {
-        const player = createPlayerForTesting();
-        expect(player.townMessageChain.messages).toBe([]);
-    });
+  it('has an empty town message chain upon initialization', () => {
+    const player = createPlayerForTesting();
+    expect(player.townMessageChain.messages.length).toBe(0);
+  });
 
-    describe('receiveMessage', () => {
-        it('adds an incoming townwide message to the town message list', () => {
-            const player = createPlayerForTesting();
-            const message = createMessageForTesting(MessageType.TownMessage, player);
-            player.receiveMessage(message);
-            const townMessages = player.townMessageChain.messages;
-            expect(townMessages.length).toBe(1);
-            expect(townMessages[0]).toBe(message);
-        });
-        it('does not add other message types to the town message list', () => {
-            const player = createPlayerForTesting();
-            const message = createMessageForTesting(MessageType.ProximityMessage, player);
-            player.receiveMessage(message);
-            expect(player.townMessageChain.messages.length).toBe(0);
-        });
+  describe('receiveMessage', () => {
+    it('adds an incoming townwide message to the town message list', () => {
+      const player = createPlayerForTesting();
+      const message = createMessageForTesting(MessageType.TownMessage, player);
+      player.receiveMessage(message);
+      const townMessages = player.townMessageChain.messages;
+      expect(townMessages.length).toBe(1);
+      expect(townMessages[0]).toBe(message);
     });
+    it('does not add other message types to the town message list', () => {
+      const player = createPlayerForTesting();
+      const message = createMessageForTesting(MessageType.ProximityMessage, player);
+      player.receiveMessage(message);
+      expect(player.townMessageChain.messages.length).toBe(0);
+    });
+  });
 });

--- a/services/roomService/src/types/Player.test.ts
+++ b/services/roomService/src/types/Player.test.ts
@@ -14,7 +14,7 @@ describe('Player', () => {
       player.receiveMessage(message);
       const townMessages = player.townMessageChain.messages;
       expect(townMessages.length).toBe(1);
-      expect(townMessages[0]).toBe(message);
+      expect(townMessages).toContain(message);
     });
     it('does not add other message types to the town message list', () => {
       const player = createPlayerForTesting();

--- a/services/roomService/src/types/Player.test.ts
+++ b/services/roomService/src/types/Player.test.ts
@@ -1,0 +1,26 @@
+import { MessageType } from '../CoveyTypes';
+import { createMessageForTesting, createMessageChainForTesting, createPlayerForTesting } from '../TestUtils';
+
+describe('Player', () => {
+    it('has an empty town message chain upon initialization', () => {
+        const player = createPlayerForTesting();
+        expect(player.townMessageChain.messages).toBe([]);
+    });
+
+    describe('receiveMessage', () => {
+        it('adds an incoming townwide message to the town message list', () => {
+            const player = createPlayerForTesting();
+            const message = createMessageForTesting(MessageType.TownMessage, player);
+            player.receiveMessage(message);
+            const townMessages = player.townMessageChain.messages;
+            expect(townMessages.length).toBe(1);
+            expect(townMessages[0]).toBe(message);
+        });
+        it('does not add other message types to the town message list', () => {
+            const player = createPlayerForTesting();
+            const message = createMessageForTesting(MessageType.ProximityMessage, player);
+            player.receiveMessage(message);
+            expect(player.townMessageChain.messages.length).toBe(0);
+        });
+    });
+});

--- a/services/roomService/src/types/Player.ts
+++ b/services/roomService/src/types/Player.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
-import { UserLocation } from '../CoveyTypes';
+import { Message, MessageType, UserLocation } from '../CoveyTypes';
+import MessageChain from './MessageChain';
 
 /**
  * Each user who is connected to a town is represented by a Player object
@@ -14,6 +15,8 @@ export default class Player {
   /** The player's username, which is not guaranteed to be unique within the town * */
   private readonly _userName: string;
 
+  private _townMessageChain: MessageChain;
+
   constructor(userName: string) {
     this.location = {
       x: 0,
@@ -23,6 +26,7 @@ export default class Player {
     };
     this._userName = userName;
     this._id = nanoid();
+    this._townMessageChain = new MessageChain;
   }
 
   get userName(): string {
@@ -31,6 +35,18 @@ export default class Player {
 
   get id(): string {
     return this._id;
+  }
+
+  get townMessageChain(): MessageChain {
+    return this._townMessageChain;
+  }
+
+  receiveMessage(message: Message) {
+    switch (message.type) {
+      case  MessageType.TownMessage:
+        this._townMessageChain.addMessage(message);
+        break;
+    }
   }
 
   updateLocation(location: UserLocation): void {

--- a/services/roomService/src/types/Player.ts
+++ b/services/roomService/src/types/Player.ts
@@ -41,10 +41,12 @@ export default class Player {
     return this._townMessageChain;
   }
 
-  receiveMessage(message: Message) {
+  receiveMessage(message: Message): void {
     switch (message.type) {
       case  MessageType.TownMessage:
         this._townMessageChain.addMessage(message);
+        break;
+      default:
         break;
     }
   }

--- a/services/roomService/src/types/Player.ts
+++ b/services/roomService/src/types/Player.ts
@@ -26,7 +26,7 @@ export default class Player {
     };
     this._userName = userName;
     this._id = nanoid();
-    this._townMessageChain = new MessageChain;
+    this._townMessageChain = new MessageChain();
   }
 
   get userName(): string {


### PR DESCRIPTION
New Feature:
- Added townMessageChain to Player
- Added receiveMessage to Player
- Added tests

Refactors/Changes:
- Made message an optional variable in MessageChain construction (it's only needed when creating a direct message chain, and a player should always enter a room with an empty town and proximity MessageChain)
- Added a new PlayerData type so that Message doesn't have a cyclical dependency
- Extracted a few functions from MessageChain's test and put them in a common TestUtils file
- Linter fixups