### PR TITLE
feat: add frontend socket support

### DIFF
--- a/frontend/__mocks__/styleMock.js
+++ b/frontend/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': '<rootDir>/__mocks__/styleMock.js',
+  },
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,11 +11,11 @@ import React, {
   useState,
 } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { io, Socket } from 'socket.io-client';
+import { io } from 'socket.io-client';
 import './App.css';
-import MessageChain, { Message, MessageType } from './classes/MessageChain';
+import { Message } from './classes/MessageChain';
 import Player, { ServerPlayer, UserLocation } from './classes/Player';
-import TownsServiceClient, { TownJoinResponse } from './classes/TownsServiceClient';
+import { TownJoinResponse } from './classes/TownsServiceClient';
 import Video from './classes/Video/Video';
 import ChatSidebar from './components/Chat/ChatSidebar';
 import Login from './components/Login/Login';
@@ -31,185 +31,7 @@ import WorldMap from './components/world/WorldMap';
 import CoveyAppContext from './contexts/CoveyAppContext';
 import NearbyPlayersContext from './contexts/NearbyPlayersContext';
 import VideoContext from './contexts/VideoContext';
-import { CoveyAppState, NearbyPlayers } from './CoveyTypes';
-
-type CoveyAppUpdate =
-  | {
-      action: 'doConnect';
-      data: {
-        userName: string;
-        townFriendlyName: string;
-        townID: string;
-        townIsPubliclyListed: boolean;
-        sessionToken: string;
-        myPlayerID: string;
-        socket: Socket;
-        players: Player[];
-        emitMovement: (location: UserLocation) => void;
-      };
-    }
-  | { action: 'addPlayer'; player: Player }
-  | { action: 'playerMoved'; player: Player }
-  | { action: 'playerDisconnect'; player: Player }
-  | { action: 'weMoved'; location: UserLocation }
-  | { action: 'disconnect' }
-  | { action: 'messageReceived'; message: Message }
-  | { action: 'messageChainInactive'; directMessageId: string };
-
-function defaultAppState(): CoveyAppState {
-  return {
-    nearbyPlayers: { nearbyPlayers: [] },
-    players: [],
-    myPlayerID: '',
-    currentTownFriendlyName: '',
-    currentTownID: '',
-    currentTownIsPubliclyListed: false,
-    sessionToken: '',
-    userName: '',
-    socket: null,
-    currentLocation: {
-      x: 0,
-      y: 0,
-      rotation: 'front',
-      moving: false,
-    },
-    emitMovement: () => {},
-    apiClient: new TownsServiceClient(),
-    townMessageChain: new MessageChain(),
-    proximityMessageChain: new MessageChain(),
-    directMessageChains: {},
-  };
-}
-function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): CoveyAppState {
-  const nextState = {
-    sessionToken: state.sessionToken,
-    currentTownFriendlyName: state.currentTownFriendlyName,
-    currentTownID: state.currentTownID,
-    currentTownIsPubliclyListed: state.currentTownIsPubliclyListed,
-    myPlayerID: state.myPlayerID,
-    players: state.players,
-    currentLocation: state.currentLocation,
-    nearbyPlayers: state.nearbyPlayers,
-    userName: state.userName,
-    socket: state.socket,
-    emitMovement: state.emitMovement,
-    apiClient: state.apiClient,
-    townMessageChain: state.townMessageChain,
-    proximityMessageChain: state.proximityMessageChain,
-    directMessageChains: state.directMessageChains,
-  };
-
-  function calculateNearbyPlayers(players: Player[], currentLocation: UserLocation) {
-    const isWithinCallRadius = (p: Player, location: UserLocation) => {
-      if (p.location && location) {
-        const dx = p.location.x - location.x;
-        const dy = p.location.y - location.y;
-        const d = Math.sqrt(dx * dx + dy * dy);
-        return d < 80;
-      }
-      return false;
-    };
-    return { nearbyPlayers: players.filter(p => isWithinCallRadius(p, currentLocation)) };
-  }
-
-  function samePlayers(a1: NearbyPlayers, a2: NearbyPlayers) {
-    if (a1.nearbyPlayers.length !== a2.nearbyPlayers.length) return false;
-    const ids1 = a1.nearbyPlayers.map(p => p.id).sort();
-    const ids2 = a2.nearbyPlayers.map(p => p.id).sort();
-    return !ids1.some((val, idx) => val !== ids2[idx]);
-  }
-
-  let updatePlayer;
-  let messageChainToUpdate;
-  switch (update.action) {
-    case 'doConnect':
-      nextState.sessionToken = update.data.sessionToken;
-      nextState.myPlayerID = update.data.myPlayerID;
-      nextState.currentTownFriendlyName = update.data.townFriendlyName;
-      nextState.currentTownID = update.data.townID;
-      nextState.currentTownIsPubliclyListed = update.data.townIsPubliclyListed;
-      nextState.userName = update.data.userName;
-      nextState.emitMovement = update.data.emitMovement;
-      nextState.socket = update.data.socket;
-      nextState.players = update.data.players;
-      break;
-    case 'addPlayer':
-      nextState.players = nextState.players.concat([update.player]);
-      break;
-    case 'playerMoved':
-      updatePlayer = nextState.players.find(p => p.id === update.player.id);
-      if (updatePlayer) {
-        updatePlayer.location = update.player.location;
-      } else {
-        nextState.players = nextState.players.concat([update.player]);
-      }
-      nextState.nearbyPlayers = calculateNearbyPlayers(
-        nextState.players,
-        nextState.currentLocation,
-      );
-      if (samePlayers(nextState.nearbyPlayers, state.nearbyPlayers)) {
-        nextState.nearbyPlayers = state.nearbyPlayers;
-      }
-      break;
-    case 'weMoved':
-      nextState.currentLocation = update.location;
-      nextState.nearbyPlayers = calculateNearbyPlayers(
-        nextState.players,
-        nextState.currentLocation,
-      );
-      if (samePlayers(nextState.nearbyPlayers, state.nearbyPlayers)) {
-        nextState.nearbyPlayers = state.nearbyPlayers;
-      }
-
-      break;
-    case 'playerDisconnect':
-      nextState.players = nextState.players.filter(player => player.id !== update.player.id);
-
-      nextState.nearbyPlayers = calculateNearbyPlayers(
-        nextState.players,
-        nextState.currentLocation,
-      );
-      if (samePlayers(nextState.nearbyPlayers, state.nearbyPlayers)) {
-        nextState.nearbyPlayers = state.nearbyPlayers;
-      }
-      break;
-    case 'disconnect':
-      state.socket?.disconnect();
-      return defaultAppState();
-    case 'messageReceived':
-      switch (update.message.type) {
-        case MessageType.TownMessage:
-          nextState.townMessageChain = nextState.townMessageChain.addMessage(update.message);
-          break;
-        case MessageType.ProximityMessage:
-          nextState.proximityMessageChain = nextState.proximityMessageChain.addMessage(
-            update.message,
-          );
-          break;
-        default:
-          if (update.message.directMessageId) {
-            let directMessageChainToUpdate =
-              nextState.directMessageChains[update.message.directMessageId];
-            directMessageChainToUpdate = directMessageChainToUpdate || new MessageChain();
-            nextState.directMessageChains[
-              update.message.directMessageId
-            ] = directMessageChainToUpdate.addMessage(update.message);
-          }
-          break;
-      }
-      break;
-    case 'messageChainInactive':
-      messageChainToUpdate = nextState.directMessageChains[update.directMessageId];
-      if (messageChainToUpdate) {
-        messageChainToUpdate.isActive = false;
-      }
-      break;
-    default:
-      throw new Error('Unexpected state request');
-  }
-
-  return nextState;
-}
+import { appStateReducer, CoveyAppUpdate, defaultAppState } from './reducer';
 
 async function GameController(
   initData: TownJoinResponse,
@@ -245,9 +67,6 @@ async function GameController(
   });
   socket.on('messageReceived', (message: Message) => {
     dispatchAppUpdate({ action: 'messageReceived', message });
-  });
-  socket.on('messageChainInactive', (directMessageId: string) => {
-    dispatchAppUpdate({ action: 'messageChainInactive', directMessageId });
   });
   const emitMovement = (location: UserLocation) => {
     socket.emit('playerMovement', location);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,12 +130,6 @@ function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): CoveyApp
       nextState.emitMovement = update.data.emitMovement;
       nextState.socket = update.data.socket;
       nextState.players = update.data.players;
-      const myPlayer = update.data.players.find(player => player.id === update.data.myPlayerID);
-      if (myPlayer) {
-        nextState.townMessageChain = myPlayer.townMessageChain;
-        nextState.proximityMessageChain = myPlayer.proximityMessageChain;
-        nextState.directMessageChains = myPlayer.directMessageChains;
-      }
       break;
     case 'addPlayer':
       nextState.players = nextState.players.concat([update.player]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,6 +130,12 @@ function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): CoveyApp
       nextState.emitMovement = update.data.emitMovement;
       nextState.socket = update.data.socket;
       nextState.players = update.data.players;
+      updatePlayer = update.data.players.find(
+        playerToCheck => playerToCheck.id === update.data.myPlayerID,
+      );
+      if (updatePlayer) {
+        nextState.townMessageChain = updatePlayer.townMessageChain
+      }
       break;
     case 'addPlayer':
       nextState.players = nextState.players.concat([update.player]);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,12 +130,6 @@ function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): CoveyApp
       nextState.emitMovement = update.data.emitMovement;
       nextState.socket = update.data.socket;
       nextState.players = update.data.players;
-      updatePlayer = update.data.players.find(
-        playerToCheck => playerToCheck.id === update.data.myPlayerID,
-      );
-      if (updatePlayer) {
-        nextState.townMessageChain = updatePlayer.townMessageChain
-      }
       break;
     case 'addPlayer':
       nextState.players = nextState.players.concat([update.player]);

--- a/frontend/src/CoveyTypes.ts
+++ b/frontend/src/CoveyTypes.ts
@@ -1,31 +1,38 @@
 import { Socket } from 'socket.io-client';
+import MessageChain, { MessageChainHash } from './classes/MessageChain';
 import Player, { UserLocation } from './classes/Player';
 import TownsServiceClient from './classes/TownsServiceClient';
 
 export type CoveyEvent = 'playerMoved' | 'playerAdded' | 'playerRemoved';
 
 export type VideoRoom = {
-  twilioID: string,
-  id: string
+  twilioID: string;
+  id: string;
 };
+
 export type UserProfile = {
-  displayName: string,
-  id: string
+  displayName: string;
+  id: string;
 };
+
 export type NearbyPlayers = {
-  nearbyPlayers: Player[]
+  nearbyPlayers: Player[];
 };
+
 export type CoveyAppState = {
-  sessionToken: string,
-  userName: string,
-  currentTownFriendlyName: string,
-  currentTownID: string,
-  currentTownIsPubliclyListed: boolean,
-  myPlayerID: string,
-  players: Player[],
-  currentLocation: UserLocation,
-  nearbyPlayers: NearbyPlayers,
-  emitMovement: (location: UserLocation) => void,
-  socket: Socket | null,
-  apiClient: TownsServiceClient,
+  sessionToken: string;
+  userName: string;
+  currentTownFriendlyName: string;
+  currentTownID: string;
+  currentTownIsPubliclyListed: boolean;
+  myPlayerID: string;
+  players: Player[];
+  currentLocation: UserLocation;
+  nearbyPlayers: NearbyPlayers;
+  emitMovement: (location: UserLocation) => void;
+  socket: Socket | null;
+  apiClient: TownsServiceClient;
+  townMessageChain: MessageChain;
+  proximityMessageChain: MessageChain;
+  directMessageChains: MessageChainHash;
 };

--- a/frontend/src/TestUtils.ts
+++ b/frontend/src/TestUtils.ts
@@ -1,0 +1,30 @@
+import { nanoid } from 'nanoid';
+import MessageChain, { Message, MessageType } from './classes/MessageChain';
+
+export function createMessageForTesting(
+  type: MessageType,
+  player1Id: string,
+  player2Id?: string,
+): Message {
+  const timestamp = Date.now().toString();
+  let directMessageID;
+  if (player2Id) {
+    directMessageID = `${player1Id}:${player2Id}`;
+  }
+  return {
+    userName: nanoid(),
+    userId: player1Id,
+    location: { x: 1, y: 2, rotation: 'front', moving: false },
+    messageContent: "Omg I'm a test",
+    timestamp,
+    type,
+    directMessageId: directMessageID,
+  };
+}
+
+export function createMessageChainForTesting(startingMessage: Message): MessageChain {
+  if (startingMessage.type === MessageType.DirectMessage) {
+    return new MessageChain(startingMessage);
+  }
+  return new MessageChain().addMessage(startingMessage);
+}

--- a/frontend/src/classes/MessageChain.test.ts
+++ b/frontend/src/classes/MessageChain.test.ts
@@ -1,0 +1,74 @@
+import { nanoid } from 'nanoid';
+import { createMessageChainForTesting, createMessageForTesting } from '../TestUtils';
+import { MessageType } from './MessageChain';
+
+describe('MessageChain', () => {
+  it('get messages', () => {
+    const firstMessage = createMessageForTesting(MessageType.ProximityMessage, 'player1');
+    const testChain = createMessageChainForTesting(firstMessage);
+    expect(firstMessage).toBe(testChain.messages[0]);
+  });
+  it('get isActive', () => {
+    const firstMessage = createMessageForTesting(MessageType.ProximityMessage, 'player1');
+    const testChain = createMessageChainForTesting(firstMessage);
+    expect(testChain.isActive).toBe(true);
+  });
+  it('set isActive', () => {
+    const firstMessage = createMessageForTesting(MessageType.ProximityMessage, 'player1');
+    const testChain = createMessageChainForTesting(firstMessage);
+    expect(testChain.isActive).toBe(true);
+    testChain.isActive = false;
+    expect(testChain.isActive).toBe(false);
+  });
+  describe('get directMessageId', () => {
+    it('should return undefined for MessageChain that is not direct', () => {
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, 'player1');
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.directMessageId).toBeUndefined();
+    });
+    it('should return a string id for a MessageChain containing DirectMessages', () => {
+      const player1Id = nanoid();
+      const player2Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1Id, player2Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.directMessageId).toBe(firstMessage.directMessageId);
+      expect(testChain.directMessageId).toBe(`${player1Id}:${player2Id}`);
+    });
+  });
+  describe('get participants', () => {
+    it('should return undefined for MessageChain that is not direct', () => {
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, 'player1');
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.participants).toBeUndefined();
+    });
+    it('should return a string array for a MessageChain containing DirectMessages', () => {
+      const player1Id = nanoid();
+      const player2Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1Id, player2Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.participants?.length).toBe(2);
+    });
+  });
+  describe('addMessage', () => {
+    it('should allow for message added to active MessageChain', () => {
+      const player1Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      testChain.addMessage(secondMessage);
+      expect(testChain.messages.length).toBe(2);
+      expect(secondMessage).toBe(testChain.messages[1]);
+    });
+    it('should not allow message to add to inactive chain', () => {
+      const player1Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      testChain.isActive = false;
+      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      testChain.addMessage(secondMessage);
+      expect(testChain.messages.length).toBe(1);
+    });
+  });
+});

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -6,15 +6,6 @@ export enum MessageType {
   TownMessage,
 }
 
-export type SenderDirection = 'front' | 'back' | 'left' | 'right';
-
-export type SenderUserLocation = {
-  x: number;
-  y: number;
-  rotation: SenderDirection;
-  moving: boolean;
-};
-
 export type Message = {
   userId: string;
   userName: string;
@@ -25,6 +16,10 @@ export type Message = {
   // null for cases of Proximity and Town Message
   directMessageId: string | undefined;
 };
+
+export interface MessageChainHash {
+  [directMessageId: string]: MessageChain;
+}
 
 export default class MessageChain {
   private _messages: Message[] = [];

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -88,18 +88,3 @@ export default class MessageChain {
     this._numberUnviewed = 0;
   }
 }
-
-export type ServerMessageChain = {
-  _messages: Message[];
-  _isActive: boolean;
-  _directMessageId: string | undefined;
-  _participants: string[] | undefined;
-};
-
-export interface ServerMessageChainHash {
-  [directMessageId: string]: ServerMessageChain;
-}
-
-export interface MessageChainHash {
-  [directMessageId: string]: MessageChain;
-}

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -33,11 +33,16 @@ export default class MessageChain {
   // how many messages have not been viewed by the curret users;
   private _numberUnviewed: number;
 
-  constructor(directMessageId?: string | undefined, participants?: string[] | undefined) {
-    this._directMessageId = directMessageId;
-    this._participants = participants;
+  constructor(message?: Message) {
     this._isActive = true;
-    this._numberUnviewed = 0;
+    if (message && message.directMessageId) {
+      this._directMessageId = message.directMessageId;
+      this._participants = message.directMessageId?.split(':');
+      this._messages.push(message);
+      this._numberUnviewed = 1;
+    } else {
+      this._numberUnviewed = 0;
+    }
   }
 
   get messages(): Message[] {
@@ -69,8 +74,11 @@ export default class MessageChain {
    * @param newMessage The new message to add to this chain
    */
   addMessage(newMessage: Message): MessageChain {
-    this._messages.push(newMessage);
-    this._numberUnviewed += 1;
+    if (this._isActive) {
+      this._messages.push(newMessage);
+      this._numberUnviewed += 1;
+    }
+
     return this;
   }
 

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -1,5 +1,3 @@
-import { UserLocation } from './Player';
-
 export enum MessageType {
   DirectMessage,
   ProximityMessage,
@@ -7,9 +5,18 @@ export enum MessageType {
 }
 
 export type PlayerData = {
-  location: UserLocation;
+  location: SenderUserLocation;
   userName: string;
   id: string;
+};
+
+export type SenderDirection = 'front' | 'back' | 'left' | 'right';
+
+export type SenderUserLocation = {
+  x: number;
+  y: number;
+  rotation: SenderDirection;
+  moving: boolean;
 };
 
 export type Message = {
@@ -24,10 +31,14 @@ export type Message = {
 
 export default class MessageChain {
   private _messages: Message[] = [];
+
   private _isActive: boolean;
+
   private readonly _directMessageId: string | undefined;
+
   private readonly _participants: string[] | undefined;
-  private _numberUnviewed: number = 0;
+
+  private _numberUnviewed: number;
 
   constructor(
     messages?: Message[],
@@ -38,6 +49,7 @@ export default class MessageChain {
     if (!messages) {
       // just create if there's no messages already;
       this._isActive = true;
+      this._numberUnviewed = 0;
       return;
     }
     this._messages = messages;
@@ -45,6 +57,7 @@ export default class MessageChain {
     this._isActive = isActive || true;
     this._directMessageId = directMessageId;
     this._participants = participants;
+    this._numberUnviewed = 0;
   }
 
   get messages(): Message[] {
@@ -55,6 +68,10 @@ export default class MessageChain {
     return this._isActive;
   }
 
+  set isActive(value: boolean) {
+    this._isActive = value;
+  }
+
   get directMessageId(): string | undefined {
     return this._directMessageId;
   }
@@ -63,17 +80,13 @@ export default class MessageChain {
     return this._participants;
   }
 
-  set isActive(value: boolean) {
-    this._isActive = value;
-  }
-
   /**
    * Adds new message to this message chain.
    * @param newMessage The new message to add to this chain
    */
   addMessage(newMessage: Message): MessageChain {
     this._messages.push(newMessage);
-    this._numberUnviewed = this._numberUnviewed + 1;
+    this._numberUnviewed += 1;
     return this;
   }
 

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -4,12 +4,6 @@ export enum MessageType {
   TownMessage,
 }
 
-export type PlayerData = {
-  location: SenderUserLocation;
-  userName: string;
-  id: string;
-};
-
 export type SenderDirection = 'front' | 'back' | 'left' | 'right';
 
 export type SenderUserLocation = {
@@ -17,6 +11,12 @@ export type SenderUserLocation = {
   y: number;
   rotation: SenderDirection;
   moving: boolean;
+};
+
+export type PlayerData = {
+  location: SenderUserLocation;
+  userName: string;
+  id: string;
 };
 
 export type Message = {

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -1,3 +1,5 @@
+import { UserLocation } from './Player';
+
 export enum MessageType {
   DirectMessage,
   ProximityMessage,
@@ -13,15 +15,10 @@ export type SenderUserLocation = {
   moving: boolean;
 };
 
-export type PlayerData = {
-  location: SenderUserLocation;
-  userName: string;
-  id: string;
-};
-
 export type Message = {
-  // user who sent the message
-  user: PlayerData;
+  userId: string;
+  userName: string;
+  location: UserLocation;
   messageContent: string;
   timestamp: string;
   type: MessageType;
@@ -38,6 +35,7 @@ export default class MessageChain {
 
   private readonly _participants: string[] | undefined;
 
+  // how many messages have not been viewed by the curret users;
   private _numberUnviewed: number;
 
   constructor(directMessageId?: string | undefined, participants?: string[] | undefined) {

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -1,0 +1,110 @@
+import { UserLocation } from './Player';
+
+export enum MessageType {
+  DirectMessage,
+  ProximityMessage,
+  TownMessage,
+}
+
+export type PlayerData = {
+  location: UserLocation;
+  userName: string;
+  id: string;
+};
+
+export type Message = {
+  // user who sent the message
+  user: PlayerData;
+  messageContent: string;
+  timestamp: string;
+  type: MessageType;
+  // null for cases of Proximity and Town Message
+  directMessageId: string | undefined;
+};
+
+export default class MessageChain {
+  private _messages: Message[] = [];
+  private _isActive: boolean;
+  private readonly _directMessageId: string | undefined;
+  private readonly _participants: string[] | undefined;
+  private _numberUnviewed: number = 0;
+
+  constructor(
+    messages?: Message[],
+    isActive?: boolean | undefined,
+    directMessageId?: string | undefined,
+    participants?: string[] | undefined,
+  ) {
+    if (!messages) {
+      // just create if there's no messages already;
+      this._isActive = true;
+      return;
+    }
+    this._messages = messages;
+    this._numberUnviewed = messages.length;
+    this._isActive = isActive || true;
+    this._directMessageId = directMessageId;
+    this._participants = participants;
+  }
+
+  get messages(): Message[] {
+    return this._messages;
+  }
+
+  get isActive(): boolean {
+    return this._isActive;
+  }
+
+  get directMessageId(): string | undefined {
+    return this._directMessageId;
+  }
+
+  get participants(): string[] | undefined {
+    return this._participants;
+  }
+
+  set isActive(value: boolean) {
+    this._isActive = value;
+  }
+
+  /**
+   * Adds new message to this message chain.
+   * @param newMessage The new message to add to this chain
+   */
+  addMessage(newMessage: Message): MessageChain {
+    this._messages.push(newMessage);
+    this._numberUnviewed = this._numberUnviewed + 1;
+    return this;
+  }
+
+  /**
+   * sets number of unviewed messages to zero
+   */
+  resetNumberUnviewed() {
+    this._numberUnviewed = 0;
+  }
+
+  static fromServerMessageChain(messageChainFromServer: ServerMessageChain): MessageChain {
+    return new MessageChain(
+      messageChainFromServer._messages,
+      messageChainFromServer._isActive,
+      messageChainFromServer._directMessageId,
+      messageChainFromServer._participants,
+    );
+  }
+}
+
+export type ServerMessageChain = {
+  _messages: Message[];
+  _isActive: boolean;
+  _directMessageId: string | undefined;
+  _participants: string[] | undefined;
+};
+
+export interface ServerMessageChainHash {
+  [directMessageId: string]: ServerMessageChain;
+}
+
+export interface MessageChainHash {
+  [directMessageId: string]: MessageChain;
+}

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -40,23 +40,10 @@ export default class MessageChain {
 
   private _numberUnviewed: number;
 
-  constructor(
-    messages?: Message[],
-    isActive?: boolean | undefined,
-    directMessageId?: string | undefined,
-    participants?: string[] | undefined,
-  ) {
-    if (!messages) {
-      // just create if there's no messages already;
-      this._isActive = true;
-      this._numberUnviewed = 0;
-      return;
-    }
-    this._messages = messages;
-    this._numberUnviewed = messages.length;
-    this._isActive = isActive || true;
+  constructor(directMessageId?: string | undefined, participants?: string[] | undefined) {
     this._directMessageId = directMessageId;
     this._participants = participants;
+    this._isActive = true;
     this._numberUnviewed = 0;
   }
 
@@ -80,6 +67,10 @@ export default class MessageChain {
     return this._participants;
   }
 
+  get numberUnviewed(): number {
+    return this._numberUnviewed;
+  }
+
   /**
    * Adds new message to this message chain.
    * @param newMessage The new message to add to this chain
@@ -93,17 +84,8 @@ export default class MessageChain {
   /**
    * sets number of unviewed messages to zero
    */
-  resetNumberUnviewed() {
+  resetNumberUnviewed(): void {
     this._numberUnviewed = 0;
-  }
-
-  static fromServerMessageChain(messageChainFromServer: ServerMessageChain): MessageChain {
-    return new MessageChain(
-      messageChainFromServer._messages,
-      messageChainFromServer._isActive,
-      messageChainFromServer._directMessageId,
-      messageChainFromServer._participants,
-    );
   }
 }
 

--- a/frontend/src/classes/Player.ts
+++ b/frontend/src/classes/Player.ts
@@ -1,3 +1,21 @@
+import MessageChain, {
+  MessageChainHash,
+  ServerMessageChain,
+  ServerMessageChainHash,
+} from './MessageChain';
+
+function fromServerMessageChainHash(
+  messageChainHashFromServer: ServerMessageChainHash,
+): MessageChainHash {
+  let translatedMessageChainHash: MessageChainHash = {};
+  for (let directMessageId in messageChainHashFromServer) {
+    translatedMessageChainHash[directMessageId] = MessageChain.fromServerMessageChain(
+      messageChainHashFromServer[directMessageId],
+    );
+  }
+  return translatedMessageChainHash;
+}
+
 export default class Player {
   public location?: UserLocation;
 
@@ -5,14 +23,28 @@ export default class Player {
 
   private readonly _userName: string;
 
+  private _townMessageChain: MessageChain;
+  private _proximityMessageChain: MessageChain;
+  private _directMessageChains: MessageChainHash;
+
   public sprite?: Phaser.GameObjects.Sprite;
 
   public label?: Phaser.GameObjects.Text;
 
-  constructor(id: string, userName: string, location: UserLocation) {
+  constructor(
+    id: string,
+    userName: string,
+    location: UserLocation,
+    townMessageChain: ServerMessageChain,
+    proximityMessageChain: ServerMessageChain,
+    directMessageChains: ServerMessageChainHash,
+  ) {
     this._id = id;
     this._userName = userName;
     this.location = location;
+    this._townMessageChain = MessageChain.fromServerMessageChain(townMessageChain);
+    this._proximityMessageChain = MessageChain.fromServerMessageChain(proximityMessageChain);
+    this._directMessageChains = fromServerMessageChainHash(directMessageChains);
   }
 
   get userName(): string {
@@ -23,17 +55,43 @@ export default class Player {
     return this._id;
   }
 
+  get townMessageChain(): MessageChain {
+    return this._townMessageChain;
+  }
+
+  get proximityMessageChain(): MessageChain {
+    return this._proximityMessageChain;
+  }
+
+  get directMessageChains(): MessageChainHash {
+    return this._directMessageChains;
+  }
+
   static fromServerPlayer(playerFromServer: ServerPlayer): Player {
-    return new Player(playerFromServer._id, playerFromServer._userName, playerFromServer.location);
+    return new Player(
+      playerFromServer._id,
+      playerFromServer._userName,
+      playerFromServer.location,
+      playerFromServer._townMessageChain,
+      playerFromServer._proximityMessageChain,
+      playerFromServer._directMessageChains,
+    );
   }
 }
-export type ServerPlayer = { _id: string, _userName: string, location: UserLocation };
+export type ServerPlayer = {
+  _id: string;
+  _userName: string;
+  location: UserLocation;
+  _townMessageChain: ServerMessageChain;
+  _proximityMessageChain: ServerMessageChain;
+  _directMessageChains: ServerMessageChainHash;
+};
 
-export type Direction = 'front'|'back'|'left'|'right';
+export type Direction = 'front' | 'back' | 'left' | 'right';
 
 export type UserLocation = {
-  x: number,
-  y: number,
-  rotation: Direction,
-  moving: boolean
+  x: number;
+  y: number;
+  rotation: Direction;
+  moving: boolean;
 };

--- a/frontend/src/classes/Player.ts
+++ b/frontend/src/classes/Player.ts
@@ -7,12 +7,12 @@ import MessageChain, {
 function fromServerMessageChainHash(
   messageChainHashFromServer: ServerMessageChainHash,
 ): MessageChainHash {
-  let translatedMessageChainHash: MessageChainHash = {};
-  for (let directMessageId in messageChainHashFromServer) {
+  const translatedMessageChainHash: MessageChainHash = {};
+  Object.keys(messageChainHashFromServer).forEach(directMessageId => {
     translatedMessageChainHash[directMessageId] = MessageChain.fromServerMessageChain(
       messageChainHashFromServer[directMessageId],
     );
-  }
+  });
   return translatedMessageChainHash;
 }
 
@@ -24,7 +24,9 @@ export default class Player {
   private readonly _userName: string;
 
   private _townMessageChain: MessageChain;
+
   private _proximityMessageChain: MessageChain;
+
   private _directMessageChains: MessageChainHash;
 
   public sprite?: Phaser.GameObjects.Sprite;
@@ -35,16 +37,22 @@ export default class Player {
     id: string,
     userName: string,
     location: UserLocation,
-    townMessageChain: ServerMessageChain,
-    proximityMessageChain: ServerMessageChain,
-    directMessageChains: ServerMessageChainHash,
+    townMessageChain?: ServerMessageChain,
+    proximityMessageChain?: ServerMessageChain,
+    directMessageChains?: ServerMessageChainHash,
   ) {
     this._id = id;
     this._userName = userName;
     this.location = location;
-    this._townMessageChain = MessageChain.fromServerMessageChain(townMessageChain);
-    this._proximityMessageChain = MessageChain.fromServerMessageChain(proximityMessageChain);
-    this._directMessageChains = fromServerMessageChainHash(directMessageChains);
+    this._townMessageChain = townMessageChain
+      ? MessageChain.fromServerMessageChain(townMessageChain)
+      : new MessageChain();
+    this._proximityMessageChain = proximityMessageChain
+      ? MessageChain.fromServerMessageChain(proximityMessageChain)
+      : new MessageChain();
+    this._directMessageChains = directMessageChains
+      ? fromServerMessageChainHash(directMessageChains)
+      : {};
   }
 
   get userName(): string {

--- a/frontend/src/classes/Player.ts
+++ b/frontend/src/classes/Player.ts
@@ -38,8 +38,6 @@ export default class Player {
     userName: string,
     location: UserLocation,
     townMessageChain?: ServerMessageChain,
-    proximityMessageChain?: ServerMessageChain,
-    directMessageChains?: ServerMessageChainHash,
   ) {
     this._id = id;
     this._userName = userName;
@@ -47,12 +45,8 @@ export default class Player {
     this._townMessageChain = townMessageChain
       ? MessageChain.fromServerMessageChain(townMessageChain)
       : new MessageChain();
-    this._proximityMessageChain = proximityMessageChain
-      ? MessageChain.fromServerMessageChain(proximityMessageChain)
-      : new MessageChain();
-    this._directMessageChains = directMessageChains
-      ? fromServerMessageChainHash(directMessageChains)
-      : {};
+    this._proximityMessageChain = new MessageChain();
+    this._directMessageChains = {};
   }
 
   get userName(): string {
@@ -81,8 +75,6 @@ export default class Player {
       playerFromServer._userName,
       playerFromServer.location,
       playerFromServer._townMessageChain,
-      playerFromServer._proximityMessageChain,
-      playerFromServer._directMessageChains,
     );
   }
 }

--- a/frontend/src/classes/Player.ts
+++ b/frontend/src/classes/Player.ts
@@ -1,8 +1,4 @@
-import MessageChain, {
-  MessageChainHash,
-  ServerMessageChain,
-  ServerMessageChainHash,
-} from './MessageChain';
+import { ServerMessageChain, ServerMessageChainHash } from './MessageChain';
 
 export default class Player {
   public location?: UserLocation;
@@ -10,12 +6,6 @@ export default class Player {
   private readonly _id: string;
 
   private readonly _userName: string;
-
-  private _townMessageChain: MessageChain;
-
-  private _proximityMessageChain: MessageChain;
-
-  private _directMessageChains: MessageChainHash;
 
   public sprite?: Phaser.GameObjects.Sprite;
 
@@ -25,9 +15,6 @@ export default class Player {
     this._id = id;
     this._userName = userName;
     this.location = location;
-    this._townMessageChain = new MessageChain();
-    this._proximityMessageChain = new MessageChain();
-    this._directMessageChains = {};
   }
 
   get userName(): string {
@@ -38,22 +25,13 @@ export default class Player {
     return this._id;
   }
 
-  get townMessageChain(): MessageChain {
-    return this._townMessageChain;
-  }
-
-  get proximityMessageChain(): MessageChain {
-    return this._proximityMessageChain;
-  }
-
-  get directMessageChains(): MessageChainHash {
-    return this._directMessageChains;
-  }
-
   static fromServerPlayer(playerFromServer: ServerPlayer): Player {
     return new Player(playerFromServer._id, playerFromServer._userName, playerFromServer.location);
   }
 }
+
+// message chains may be returned from the server, but we don't actually store
+// them as part of the player
 export type ServerPlayer = {
   _id: string;
   _userName: string;

--- a/frontend/src/classes/Player.ts
+++ b/frontend/src/classes/Player.ts
@@ -4,18 +4,6 @@ import MessageChain, {
   ServerMessageChainHash,
 } from './MessageChain';
 
-function fromServerMessageChainHash(
-  messageChainHashFromServer: ServerMessageChainHash,
-): MessageChainHash {
-  const translatedMessageChainHash: MessageChainHash = {};
-  Object.keys(messageChainHashFromServer).forEach(directMessageId => {
-    translatedMessageChainHash[directMessageId] = MessageChain.fromServerMessageChain(
-      messageChainHashFromServer[directMessageId],
-    );
-  });
-  return translatedMessageChainHash;
-}
-
 export default class Player {
   public location?: UserLocation;
 
@@ -33,18 +21,11 @@ export default class Player {
 
   public label?: Phaser.GameObjects.Text;
 
-  constructor(
-    id: string,
-    userName: string,
-    location: UserLocation,
-    townMessageChain?: ServerMessageChain,
-  ) {
+  constructor(id: string, userName: string, location: UserLocation) {
     this._id = id;
     this._userName = userName;
     this.location = location;
-    this._townMessageChain = townMessageChain
-      ? MessageChain.fromServerMessageChain(townMessageChain)
-      : new MessageChain();
+    this._townMessageChain = new MessageChain();
     this._proximityMessageChain = new MessageChain();
     this._directMessageChains = {};
   }
@@ -70,12 +51,7 @@ export default class Player {
   }
 
   static fromServerPlayer(playerFromServer: ServerPlayer): Player {
-    return new Player(
-      playerFromServer._id,
-      playerFromServer._userName,
-      playerFromServer.location,
-      playerFromServer._townMessageChain,
-    );
+    return new Player(playerFromServer._id, playerFromServer._userName, playerFromServer.location);
   }
 }
 export type ServerPlayer = {

--- a/frontend/src/classes/Player.ts
+++ b/frontend/src/classes/Player.ts
@@ -1,5 +1,3 @@
-import { ServerMessageChain, ServerMessageChainHash } from './MessageChain';
-
 export default class Player {
   public location?: UserLocation;
 
@@ -30,15 +28,10 @@ export default class Player {
   }
 }
 
-// message chains may be returned from the server, but we don't actually store
-// them as part of the player
 export type ServerPlayer = {
   _id: string;
   _userName: string;
   location: UserLocation;
-  _townMessageChain: ServerMessageChain;
-  _proximityMessageChain: ServerMessageChain;
-  _directMessageChains: ServerMessageChainHash;
 };
 
 export type Direction = 'front' | 'back' | 'left' | 'right';

--- a/frontend/src/components/Login/TownSelectionPart1.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart1.test.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable no-await-in-loop,@typescript-eslint/no-loop-func,no-restricted-syntax */
-import React from 'react'
-import '@testing-library/jest-dom'
-import { ChakraProvider } from '@chakra-ui/react'
-import { render, waitFor, within } from '@testing-library/react'
+import { ChakraProvider } from '@chakra-ui/react';
+import '@testing-library/jest-dom';
+import { render, waitFor, within } from '@testing-library/react';
 import { nanoid } from 'nanoid';
+import React from 'react';
+import MessageChain from '../../classes/MessageChain';
 import TownsServiceClient from '../../classes/TownsServiceClient';
-import TownSelection from './TownSelection';
 import Video from '../../classes/Video/Video';
 import CoveyAppContext from '../../contexts/CoveyAppContext';
+import TownSelection from './TownSelection';
 
 const mockConnect = jest.fn(() => Promise.resolve());
 
@@ -16,16 +17,16 @@ jest.mock('../../classes/TownsServiceClient');
 jest.mock('../../classes/Video/Video');
 jest.mock('../VideoCall/VideoFrontend/hooks/useVideoContext/useVideoContext.ts', () => ({
   __esModule: true, // this property makes it work
-  default: () => ({ connect: mockConnect })
+  default: () => ({ connect: mockConnect }),
 }));
-jest.mock("@chakra-ui/react", () => {
-  const ui = jest.requireActual("@chakra-ui/react");
-  const mockUseToast = () => (mockToast);
+jest.mock('@chakra-ui/react', () => {
+  const ui = jest.requireActual('@chakra-ui/react');
+  const mockUseToast = () => mockToast;
   return {
     ...ui,
     useToast: mockUseToast,
   };
-})
+});
 const doLoginMock = jest.fn();
 const mocklistTowns = jest.fn();
 const mockCreateTown = jest.fn();
@@ -33,193 +34,202 @@ const mockVideoSetup = jest.fn();
 TownsServiceClient.prototype.listTowns = mocklistTowns;
 TownsServiceClient.prototype.createTown = mockCreateTown;
 Video.setup = mockVideoSetup;
-const listTowns = (suffix: string) => Promise.resolve({
-  towns: [
-    {
-      friendlyName: `town1${suffix}`,
-      coveyTownID: `1${suffix}`,
-      currentOccupancy: 0,
-      maximumOccupancy: 1,
-    },
-    {
-      friendlyName: `town2${suffix}`,
-      coveyTownID: `2${suffix}`,
-      currentOccupancy: 2,
-      maximumOccupancy: 10,
-    },
-    {
-      friendlyName: `town3${suffix}`,
-      coveyTownID: `3${suffix}`,
-      currentOccupancy: 1,
-      maximumOccupancy: 1,
-    },
-    {
-      friendlyName: `town4${suffix}`,
-      coveyTownID: `4${suffix}`,
-      currentOccupancy: 8,
-      maximumOccupancy: 8,
-    },
-    {
-      friendlyName: `town5${suffix}`,
-      coveyTownID: `5${suffix}`,
-      currentOccupancy: 9,
-      maximumOccupancy: 5,
-    },
-    {
-      friendlyName: `town6${suffix}`,
-      coveyTownID: `6${suffix}`,
-      currentOccupancy: 99,
-      maximumOccupancy: 100,
-    },
-  ].map(a => ({
-    sort: Math.random(),
-    value: a
-  }))
-    .sort((a, b) => a.sort - b.sort)
-    .map((a) => a.value)
-});
+const listTowns = (suffix: string) =>
+  Promise.resolve({
+    towns: [
+      {
+        friendlyName: `town1${suffix}`,
+        coveyTownID: `1${suffix}`,
+        currentOccupancy: 0,
+        maximumOccupancy: 1,
+      },
+      {
+        friendlyName: `town2${suffix}`,
+        coveyTownID: `2${suffix}`,
+        currentOccupancy: 2,
+        maximumOccupancy: 10,
+      },
+      {
+        friendlyName: `town3${suffix}`,
+        coveyTownID: `3${suffix}`,
+        currentOccupancy: 1,
+        maximumOccupancy: 1,
+      },
+      {
+        friendlyName: `town4${suffix}`,
+        coveyTownID: `4${suffix}`,
+        currentOccupancy: 8,
+        maximumOccupancy: 8,
+      },
+      {
+        friendlyName: `town5${suffix}`,
+        coveyTownID: `5${suffix}`,
+        currentOccupancy: 9,
+        maximumOccupancy: 5,
+      },
+      {
+        friendlyName: `town6${suffix}`,
+        coveyTownID: `6${suffix}`,
+        currentOccupancy: 99,
+        maximumOccupancy: 100,
+      },
+    ]
+      .map(a => ({
+        sort: Math.random(),
+        value: a,
+      }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(a => a.value),
+  });
 
 function wrappedTownSelection() {
-  return <ChakraProvider><CoveyAppContext.Provider value={{
-    nearbyPlayers: { nearbyPlayers: [] },
-    players: [],
-    myPlayerID: '',
-    currentTownID: '',
-    currentTownIsPubliclyListed: false,
-    currentTownFriendlyName: '',
-    sessionToken: '',
-    userName: '',
-    socket: null,
-    currentLocation: {
-      x: 0,
-      y: 0,
-      rotation: 'front',
-      moving: false,
-    },
-    emitMovement: () => {
-    },
-    apiClient: new TownsServiceClient(),
-  }}>
-    <TownSelection doLogin={doLoginMock}/></CoveyAppContext.Provider></ChakraProvider>;
+  return (
+    <ChakraProvider>
+      <CoveyAppContext.Provider
+        value={{
+          nearbyPlayers: { nearbyPlayers: [] },
+          players: [],
+          myPlayerID: '',
+          currentTownID: '',
+          currentTownIsPubliclyListed: false,
+          currentTownFriendlyName: '',
+          sessionToken: '',
+          userName: '',
+          socket: null,
+          currentLocation: {
+            x: 0,
+            y: 0,
+            rotation: 'front',
+            moving: false,
+          },
+          emitMovement: () => {},
+          apiClient: new TownsServiceClient(),
+          townMessageChain: new MessageChain(),
+          proximityMessageChain: new MessageChain(),
+          directMessageChains: {},
+        }}>
+        <TownSelection doLogin={doLoginMock} />
+      </CoveyAppContext.Provider>
+    </ChakraProvider>
+  );
 }
 
 describe('Part 1 - Public room listing', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mocklistTowns.mockReset();
-  })
+  });
   it('is called when rendering (hopefully by a useeffect, this will be checked manually)', async () => {
     jest.useRealTimers();
     mocklistTowns.mockImplementation(() => listTowns(nanoid()));
     const renderData = render(wrappedTownSelection());
-    await waitFor(() => {
-      expect(mocklistTowns)
-        .toHaveBeenCalledTimes(1);
-    }, {timeout: 200})
+    await waitFor(
+      () => {
+        expect(mocklistTowns).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 200 },
+    );
     renderData.unmount();
   });
   it('updates every 2000 msec', async () => {
     mocklistTowns.mockImplementation(() => listTowns(nanoid()));
     const renderData = render(wrappedTownSelection());
     await waitFor(() => {
-      expect(mocklistTowns)
-        .toBeCalledTimes(1);
-    })
+      expect(mocklistTowns).toBeCalledTimes(1);
+    });
     jest.advanceTimersByTime(2000);
     await waitFor(() => {
-      expect(mocklistTowns)
-        .toBeCalledTimes(2);
-    })
+      expect(mocklistTowns).toBeCalledTimes(2);
+    });
     jest.advanceTimersByTime(1000);
     await waitFor(() => {
-      expect(mocklistTowns)
-        .toBeCalledTimes(2);
-    })
+      expect(mocklistTowns).toBeCalledTimes(2);
+    });
     renderData.unmount();
   });
   it('stops updating when unmounted', async () => {
     mocklistTowns.mockImplementation(() => listTowns(nanoid()));
     const renderData = render(wrappedTownSelection());
     await waitFor(() => {
-      expect(mocklistTowns)
-        .toBeCalledTimes(1);
-    })
+      expect(mocklistTowns).toBeCalledTimes(1);
+    });
     jest.advanceTimersByTime(2000);
     await waitFor(() => {
-      expect(mocklistTowns)
-        .toBeCalledTimes(2);
-    })
+      expect(mocklistTowns).toBeCalledTimes(2);
+    });
     renderData.unmount();
     jest.advanceTimersByTime(10000);
     await waitFor(() => {
-      expect(mocklistTowns)
-        .toBeCalledTimes(2);
-    })
+      expect(mocklistTowns).toBeCalledTimes(2);
+    });
   });
   it('updates the page with all towns stored in currentPublicTowns', async () => {
     const suffix1 = nanoid();
     const suffix2 = nanoid();
-    const expectedTowns1 = await listTowns(suffix1)
-    const expectedTowns2 = await listTowns(suffix2)
+    const expectedTowns1 = await listTowns(suffix1);
+    const expectedTowns2 = await listTowns(suffix2);
     mocklistTowns.mockImplementation(() => listTowns(suffix1));
     const renderData = render(wrappedTownSelection());
     await waitFor(() => {
-      expectedTowns1.towns.map((town) => expect(renderData.getByText(town.friendlyName))
-        .toBeInTheDocument());
-    })
+      expectedTowns1.towns.map(town =>
+        expect(renderData.getByText(town.friendlyName)).toBeInTheDocument(),
+      );
+    });
     mocklistTowns.mockImplementation(() => listTowns(suffix2));
     jest.advanceTimersByTime(2000);
     await waitFor(() => {
-      expectedTowns2.towns.forEach((town) => expect(renderData.getByText(town.friendlyName))
-        .toBeInTheDocument());
-      expectedTowns1.towns.forEach((town) => expect(renderData.queryByText(town.friendlyName))
-        .not
-        .toBeInTheDocument());
-    })
-
+      expectedTowns2.towns.forEach(town =>
+        expect(renderData.getByText(town.friendlyName)).toBeInTheDocument(),
+      );
+      expectedTowns1.towns.forEach(town =>
+        expect(renderData.queryByText(town.friendlyName)).not.toBeInTheDocument(),
+      );
+    });
   });
   it('does not include the hardcoded demo in the listing', async () => {
     const suffix = nanoid();
-    const expectedTowns1 = await listTowns(suffix)
+    const expectedTowns1 = await listTowns(suffix);
     mocklistTowns.mockImplementation(() => listTowns(suffix));
     const renderData = render(wrappedTownSelection());
     await waitFor(() => {
-      expectedTowns1.towns.map((town) => expect(renderData.getByText(town.friendlyName))
-        .toBeInTheDocument());
-    })
-    expect(renderData.queryByText('demoTownName'))
-      .not
-      .toBeInTheDocument();
+      expectedTowns1.towns.map(town =>
+        expect(renderData.getByText(town.friendlyName)).toBeInTheDocument(),
+      );
+    });
+    expect(renderData.queryByText('demoTownName')).not.toBeInTheDocument();
   });
   it('sorts towns by occupancy descending', async () => {
     const suffix1 = nanoid();
     const suffix2 = nanoid();
-    const expectedTowns1 = await listTowns(suffix1)
-    expectedTowns1.towns = expectedTowns1.towns.sort((a, b) => b.currentOccupancy - a.currentOccupancy);
+    const expectedTowns1 = await listTowns(suffix1);
+    expectedTowns1.towns = expectedTowns1.towns.sort(
+      (a, b) => b.currentOccupancy - a.currentOccupancy,
+    );
 
-    const expectedTowns2 = await listTowns(suffix2)
-    expectedTowns2.towns = expectedTowns2.towns.sort((a, b) => b.currentOccupancy - a.currentOccupancy);
+    const expectedTowns2 = await listTowns(suffix2);
+    expectedTowns2.towns = expectedTowns2.towns.sort(
+      (a, b) => b.currentOccupancy - a.currentOccupancy,
+    );
 
     mocklistTowns.mockImplementation(() => listTowns(suffix1));
     const renderData = render(wrappedTownSelection());
     await waitFor(() => {
-      expectedTowns1.towns.map((town) => expect(renderData.getByText(town.friendlyName))
-        .toBeInTheDocument());
-    })
+      expectedTowns1.towns.map(town =>
+        expect(renderData.getByText(town.friendlyName)).toBeInTheDocument(),
+      );
+    });
     // All towns are in doc, now make sure they are sorted by occupancy
     let rows = renderData.getAllByRole('row');
-    for (let i = 1; i < rows.length; i += 1) { // off-by-one for the header row
+    for (let i = 1; i < rows.length; i += 1) {
+      // off-by-one for the header row
       // console.log(rows[i]);
-      const existing = within(rows[i])
-        .getByText(expectedTowns1.towns[i - 1].friendlyName);
-      expect(existing)
-        .toBeInTheDocument();
+      const existing = within(rows[i]).getByText(expectedTowns1.towns[i - 1].friendlyName);
+      expect(existing).toBeInTheDocument();
       for (let j = 0; j < expectedTowns1.towns.length; j += 1) {
         if (j !== i - 1) {
-          expect(within(rows[i])
-            .queryByText(expectedTowns1.towns[j].friendlyName))
-            .not
-            .toBeInTheDocument();
+          expect(
+            within(rows[i]).queryByText(expectedTowns1.towns[j].friendlyName),
+          ).not.toBeInTheDocument();
         }
       }
     }
@@ -227,24 +237,23 @@ describe('Part 1 - Public room listing', () => {
     mocklistTowns.mockImplementation(() => listTowns(suffix2));
     jest.advanceTimersByTime(2000);
     await waitFor(() =>
-      expectedTowns2.towns.map((town) => expect(renderData.getByText(town.friendlyName))
-        .toBeInTheDocument())
-    )
+      expectedTowns2.towns.map(town =>
+        expect(renderData.getByText(town.friendlyName)).toBeInTheDocument(),
+      ),
+    );
 
     // All towns are in doc, now make sure they are sorted by occupancy
     rows = renderData.getAllByRole('row');
-    for (let i = 1; i < rows.length; i += 1) { // off-by-one for the header row
+    for (let i = 1; i < rows.length; i += 1) {
+      // off-by-one for the header row
       // console.log(rows[i]);
-      const existing = within(rows[i])
-        .getByText(expectedTowns2.towns[i - 1].friendlyName);
-      expect(existing)
-        .toBeInTheDocument();
+      const existing = within(rows[i]).getByText(expectedTowns2.towns[i - 1].friendlyName);
+      expect(existing).toBeInTheDocument();
       for (let j = 0; j < expectedTowns2.towns.length; j += 1) {
         if (j !== i - 1) {
-          expect(within(rows[i])
-            .queryByText(expectedTowns2.towns[j].friendlyName))
-            .not
-            .toBeInTheDocument();
+          expect(
+            within(rows[i]).queryByText(expectedTowns2.towns[j].friendlyName),
+          ).not.toBeInTheDocument();
         }
       }
     }
@@ -252,36 +261,31 @@ describe('Part 1 - Public room listing', () => {
   it('represents each row in the table as specified', async () => {
     const suffix1 = nanoid();
     const expectedTowns = await listTowns(suffix1);
-    expectedTowns.towns = expectedTowns.towns.sort((a, b) => b.currentOccupancy - a.currentOccupancy);
+    expectedTowns.towns = expectedTowns.towns.sort(
+      (a, b) => b.currentOccupancy - a.currentOccupancy,
+    );
     mocklistTowns.mockImplementation(() => listTowns(suffix1));
     const renderData = render(wrappedTownSelection());
     await waitFor(() => {
-      expectedTowns.towns.forEach((town) => expect(renderData.getByText(town.friendlyName))
-        .toBeInTheDocument());
-    })
+      expectedTowns.towns.forEach(town =>
+        expect(renderData.getByText(town.friendlyName)).toBeInTheDocument(),
+      );
+    });
     const rows = renderData.getAllByRole('row');
-    expectedTowns.towns.forEach((town) => {
-      const row = rows.find(each => within(each)
-        .queryByText(town.coveyTownID));
+    expectedTowns.towns.forEach(town => {
+      const row = rows.find(each => within(each).queryByText(town.coveyTownID));
       if (row) {
-        const cells = within(row)
-          .queryAllByRole('cell');
+        const cells = within(row).queryAllByRole('cell');
         // Cell order: friendlyName, TownID, occupancy/join + button
-        expect(cells.length)
-          .toBe(3);
-        expect(within(cells[0])
-          .queryByText(town.friendlyName))
-          .toBeInTheDocument();
-        expect(within(cells[1])
-          .queryByText(town.coveyTownID))
-          .toBeInTheDocument();
-        expect(within(cells[2])
-          .queryByText(`${town.currentOccupancy}/${town.maximumOccupancy}`))
-          .toBeInTheDocument();
+        expect(cells.length).toBe(3);
+        expect(within(cells[0]).queryByText(town.friendlyName)).toBeInTheDocument();
+        expect(within(cells[1]).queryByText(town.coveyTownID)).toBeInTheDocument();
+        expect(
+          within(cells[2]).queryByText(`${town.currentOccupancy}/${town.maximumOccupancy}`),
+        ).toBeInTheDocument();
       } else {
         fail(`Could not find row for town ${town.coveyTownID}`);
       }
-    })
+    });
   });
 });
-

--- a/frontend/src/components/Login/TownSelectionPart2.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart2.test.tsx
@@ -9,6 +9,7 @@ import TownsServiceClient, { TownListResponse } from '../../classes/TownsService
 import TownSelection from './TownSelection';
 import Video from '../../classes/Video/Video';
 import CoveyAppContext from '../../contexts/CoveyAppContext';
+import MessageChain from '../../classes/MessageChain'
 
 const mockConnect = jest.fn(() => Promise.resolve());
 
@@ -100,6 +101,9 @@ function wrappedTownSelection() {
     emitMovement: () => {
     },
     apiClient: new TownsServiceClient(),
+    townMessageChain: new MessageChain(),
+    proximityMessageChain: new MessageChain(),
+    directMessageChains: {},
   }}>
     <TownSelection doLogin={doLoginMock}/></CoveyAppContext.Provider></ChakraProvider>;
 }

--- a/frontend/src/components/Login/TownSelectionPart3.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart3.test.tsx
@@ -9,6 +9,7 @@ import TownsServiceClient from '../../classes/TownsServiceClient';
 import TownSelection from './TownSelection';
 import Video from '../../classes/Video/Video';
 import CoveyAppContext from '../../contexts/CoveyAppContext';
+import MessageChain from '../../classes/MessageChain'
 
 const mockConnect = jest.fn(() => Promise.resolve());
 
@@ -100,6 +101,9 @@ function wrappedTownSelection() {
     emitMovement: () => {
     },
     apiClient: new TownsServiceClient(),
+    townMessageChain: new MessageChain(),
+    proximityMessageChain: new MessageChain(),
+    directMessageChains: {},
   }}>
     <TownSelection doLogin={doLoginMock}/></CoveyAppContext.Provider></ChakraProvider>;
 }

--- a/frontend/src/components/Login/TownSettings.test.tsx
+++ b/frontend/src/components/Login/TownSettings.test.tsx
@@ -8,6 +8,7 @@ import { TargetElement } from '@testing-library/user-event';
 import TownSettings from './TownSettings';
 import TownsServiceClient from '../../classes/TownsServiceClient';
 import CoveyAppContext from '../../contexts/CoveyAppContext';
+import MessageChain from '../../classes/MessageChain';
 
 const mockUseCoveyAppState = jest.fn(() => (Promise.resolve()));
 const mockToast = jest.fn();
@@ -53,6 +54,9 @@ function wrappedTownSettings() {
     emitMovement: () => {
     },
     apiClient: new TownsServiceClient(),
+    townMessageChain: new MessageChain(),
+    proximityMessageChain: new MessageChain(),
+    directMessageChains: {},
   }}>
     <TownSettings/></CoveyAppContext.Provider></ChakraProvider>;
 }

--- a/frontend/src/components/world/WorldMap.tsx
+++ b/frontend/src/components/world/WorldMap.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
 import Phaser from 'phaser';
+import React, { useEffect, useState } from 'react';
 import Player, { UserLocation } from '../../classes/Player';
 import Video from '../../classes/Video/Video';
 import useCoveyAppState from '../../hooks/useCoveyAppState';
@@ -7,7 +7,8 @@ import useCoveyAppState from '../../hooks/useCoveyAppState';
 // https://medium.com/@michaelwesthadley/modular-game-worlds-in-phaser-3-tilemaps-1-958fc7e6bbd6
 class CoveyGameScene extends Phaser.Scene {
   private player?: {
-    sprite: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody, label: Phaser.GameObjects.Text
+    sprite: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+    label: Phaser.GameObjects.Text;
   };
 
   private id?: string;
@@ -51,14 +52,14 @@ class CoveyGameScene extends Phaser.Scene {
       this.players = players;
       return;
     }
-    players.forEach((p) => {
+    players.forEach(p => {
       this.updatePlayerLocation(p);
     });
     // Remove disconnected players from board
     const disconnectedPlayers = this.players.filter(
-      (player) => !players.find((p) => p.id === player.id),
+      player => !players.find(p => p.id === player.id),
     );
-    disconnectedPlayers.forEach((disconnectedPlayer) => {
+    disconnectedPlayers.forEach(disconnectedPlayer => {
       if (disconnectedPlayer.sprite) {
         disconnectedPlayer.sprite.destroy();
         disconnectedPlayer.label?.destroy();
@@ -67,15 +68,13 @@ class CoveyGameScene extends Phaser.Scene {
     // Remove disconnected players from list
     if (disconnectedPlayers.length) {
       this.players = this.players.filter(
-        (player) => !disconnectedPlayers.find(
-          (p) => p.id === player.id,
-        ),
+        player => !disconnectedPlayers.find(p => p.id === player.id),
       );
     }
   }
 
   updatePlayerLocation(player: Player) {
-    let myPlayer = this.players.find((p) => p.id === player.id);
+    let myPlayer = this.players.find(p => p.id === player.id);
     if (!myPlayer) {
       let { location } = player;
       if (!location) {
@@ -181,16 +180,18 @@ class CoveyGameScene extends Phaser.Scene {
       }
 
       // Normalize and scale the velocity so that player can't move faster along a diagonal
-      this.player.sprite.body.velocity.normalize()
-        .scale(speed);
+      this.player.sprite.body.velocity.normalize().scale(speed);
 
       const isMoving = primaryDirection !== undefined;
       this.player.label.setX(body.x);
       this.player.label.setY(body.y - 20);
-      if (!this.lastLocation
-        || this.lastLocation.x !== body.x
-        || this.lastLocation.y !== body.y || this.lastLocation.rotation !== primaryDirection
-        || this.lastLocation.moving !== isMoving) {
+      if (
+        !this.lastLocation ||
+        this.lastLocation.x !== body.x ||
+        this.lastLocation.y !== body.y ||
+        this.lastLocation.rotation !== primaryDirection ||
+        this.lastLocation.moving !== isMoving
+      ) {
         if (!this.lastLocation) {
           this.lastLocation = {
             x: body.x,
@@ -230,56 +231,59 @@ class CoveyGameScene extends Phaser.Scene {
 
     // Object layers in Tiled let you embed extra info into a map - like a spawn point or custom
     // collision shapes. In the tmx file, there's an object layer with a point named "Spawn Point"
-    const spawnPoint = map.findObject('Objects',
-      (obj) => obj.name === 'Spawn Point') as unknown as
-      Phaser.GameObjects.Components.Transform;
-
+    const spawnPoint = (map.findObject(
+      'Objects',
+      obj => obj.name === 'Spawn Point',
+    ) as unknown) as Phaser.GameObjects.Components.Transform;
 
     // Find all of the transporters, add them to the physics engine
-    const transporters = map.createFromObjects('Objects',
-      { name: 'transporter' })
+    const transporters = map.createFromObjects('Objects', { name: 'transporter' });
     this.physics.world.enable(transporters);
 
     // For each of the transporters (rectangle objects), we need to tweak their location on the scene
     // for reasons that are not obvious to me, but this seems to work. We also set them to be invisible
     // but for debugging, you can comment out that line.
     transporters.forEach(transporter => {
-        const sprite = transporter as Phaser.GameObjects.Sprite;
-        sprite.y += 2 * sprite.height; // Phaser and Tiled seem to disagree on which corner is y
-        sprite.setVisible(false); // Comment this out to see the transporter rectangles drawn on
-                                  // the map
-      }
-    );
+      const sprite = transporter as Phaser.GameObjects.Sprite;
+      sprite.y += 2 * sprite.height; // Phaser and Tiled seem to disagree on which corner is y
+      sprite.setVisible(false); // Comment this out to see the transporter rectangles drawn on
+      // the map
+    });
 
-    const labels = map.filterObjects('Objects',(obj)=>obj.name==='label');
+    const labels = map.filterObjects('Objects', obj => obj.name === 'label');
     labels.forEach(label => {
-      if(label.x && label.y){
+      if (label.x && label.y) {
         this.add.text(label.x, label.y, label.text.text, {
           color: '#FFFFFF',
           backgroundColor: '#000000',
-        })
+        });
       }
     });
 
-
-
     const cursorKeys = this.input.keyboard.createCursorKeys();
     this.cursors.push(cursorKeys);
-    this.cursors.push(this.input.keyboard.addKeys({
-      'up': Phaser.Input.Keyboard.KeyCodes.W,
-      'down': Phaser.Input.Keyboard.KeyCodes.S,
-      'left': Phaser.Input.Keyboard.KeyCodes.A,
-      'right': Phaser.Input.Keyboard.KeyCodes.D
-    }, false) as Phaser.Types.Input.Keyboard.CursorKeys);
-    this.cursors.push(this.input.keyboard.addKeys({
-      'up': Phaser.Input.Keyboard.KeyCodes.H,
-      'down': Phaser.Input.Keyboard.KeyCodes.J,
-      'left': Phaser.Input.Keyboard.KeyCodes.K,
-      'right': Phaser.Input.Keyboard.KeyCodes.L
-    }, false) as Phaser.Types.Input.Keyboard.CursorKeys);
-
-
-
+    this.cursors.push(
+      this.input.keyboard.addKeys(
+        {
+          up: Phaser.Input.Keyboard.KeyCodes.W,
+          down: Phaser.Input.Keyboard.KeyCodes.S,
+          left: Phaser.Input.Keyboard.KeyCodes.A,
+          right: Phaser.Input.Keyboard.KeyCodes.D,
+        },
+        false,
+      ) as Phaser.Types.Input.Keyboard.CursorKeys,
+    );
+    this.cursors.push(
+      this.input.keyboard.addKeys(
+        {
+          up: Phaser.Input.Keyboard.KeyCodes.H,
+          down: Phaser.Input.Keyboard.KeyCodes.J,
+          left: Phaser.Input.Keyboard.KeyCodes.K,
+          right: Phaser.Input.Keyboard.KeyCodes.L,
+        },
+        false,
+      ) as Phaser.Types.Input.Keyboard.CursorKeys,
+    );
 
     // Create a sprite with physics enabled via the physics system. The image used for the sprite
     // has a bit of whitespace, so I'm using setSize & setOffset to control the size of the
@@ -296,7 +300,7 @@ class CoveyGameScene extends Phaser.Scene {
     });
     this.player = {
       sprite,
-      label
+      label,
     };
 
     /* Configure physics overlap behavior for when the player steps into
@@ -304,26 +308,27 @@ class CoveyGameScene extends Phaser.Scene {
     transport to the location on the map that is referenced by the 'target' property
     of the transporter.
      */
-    this.physics.add.overlap(sprite, transporters,
-      (overlappingObject, transporter)=>{
-      if(cursorKeys.space.isDown && this.player){
+    this.physics.add.overlap(sprite, transporters, (overlappingObject, transporter) => {
+      if (cursorKeys.space.isDown && this.player) {
         // In the tiled editor, set the 'target' to be an *object* pointer
         // Here, we'll see just the ID, then find the object by ID
         const transportTargetID = transporter.getData('target') as number;
-        const target = map.findObject('Objects', obj => (obj as unknown as Phaser.Types.Tilemaps.TiledObject).id === transportTargetID);
-        if(target && target.x && target.y && this.lastLocation){
+        const target = map.findObject(
+          'Objects',
+          obj => ((obj as unknown) as Phaser.Types.Tilemaps.TiledObject).id === transportTargetID,
+        );
+        if (target && target.x && target.y && this.lastLocation) {
           // Move the player to the target, update lastLocation and send it to other players
           this.player.sprite.x = target.x;
           this.player.sprite.y = target.y;
           this.lastLocation.x = target.x;
           this.lastLocation.y = target.y;
           this.emitMovement(this.lastLocation);
-        }
-        else{
+        } else {
           throw new Error(`Unable to find target object ${target}`);
         }
       }
-    })
+    });
 
     this.emitMovement({
       rotation: 'front',
@@ -389,19 +394,22 @@ class CoveyGameScene extends Phaser.Scene {
     camera.startFollow(this.player.sprite);
     camera.setBounds(0, 0, map.widthInPixels, map.heightInPixels);
 
-
-
     // Help text that has a "fixed" position on the screen
     this.add
-      .text(16, 16, `Arrow keys to move, space to transport\nCurrent town: ${this.video.townFriendlyName} (${this.video.coveyTownID})`, {
-        font: '18px monospace',
-        color: '#000000',
-        padding: {
-          x: 20,
-          y: 10
+      .text(
+        16,
+        16,
+        `Arrow keys to move, space to transport\nCurrent town: ${this.video.townFriendlyName} (${this.video.coveyTownID})`,
+        {
+          font: '18px monospace',
+          color: '#000000',
+          padding: {
+            x: 20,
+            y: 10,
+          },
+          backgroundColor: '#ffffff',
         },
-        backgroundColor: '#ffffff',
-      })
+      )
       .setScrollFactor(0)
       .setDepth(30);
 
@@ -409,7 +417,7 @@ class CoveyGameScene extends Phaser.Scene {
     if (this.players.length) {
       // Some players got added to the queue before we were ready, make sure that they have
       // sprites....
-      this.players.forEach((p) => this.updatePlayerLocation(p));
+      this.players.forEach(p => this.updatePlayerLocation(p));
     }
   }
 
@@ -428,9 +436,7 @@ class CoveyGameScene extends Phaser.Scene {
 
 export default function WorldMap(): JSX.Element {
   const video = Video.instance();
-  const {
-    emitMovement, players,
-  } = useCoveyAppState();
+  const { emitMovement, players } = useCoveyAppState();
   const [gameScene, setGameScene] = useState<CoveyGameScene>();
   useEffect(() => {
     const config = {
@@ -453,10 +459,10 @@ export default function WorldMap(): JSX.Element {
       game.scene.add('coveyBoard', newGameScene, true);
       video.pauseGame = () => {
         newGameScene.pause();
-      }
+      };
       video.unPauseGame = () => {
         newGameScene.resume();
-      }
+      };
     }
     return () => {
       game.destroy(true);
@@ -468,5 +474,5 @@ export default function WorldMap(): JSX.Element {
     gameScene?.updatePlayersLocations(players);
   }, [players, deepPlayers, gameScene]);
 
-  return <div id="map-container"/>;
+  return <div id='map-container' />;
 }

--- a/frontend/src/reducer.test.ts
+++ b/frontend/src/reducer.test.ts
@@ -1,0 +1,136 @@
+import { nanoid } from 'nanoid';
+import MessageChain, { MessageType } from './classes/MessageChain';
+import Player from './classes/Player';
+import TownsServiceClient from './classes/TownsServiceClient';
+import { CoveyAppState } from './CoveyTypes';
+import { appStateReducer } from './reducer';
+import { createMessageForTesting } from './TestUtils';
+
+jest.mock('./classes/TownsServiceClient');
+
+const createSampleAppState = (): CoveyAppState => ({
+  nearbyPlayers: { nearbyPlayers: [] },
+  players: [],
+  myPlayerID: '123',
+  currentTownFriendlyName: '',
+  currentTownID: '',
+  currentTownIsPubliclyListed: false,
+  sessionToken: '',
+  userName: '',
+  socket: null,
+  currentLocation: {
+    x: 0,
+    y: 0,
+    rotation: 'front',
+    moving: false,
+  },
+  emitMovement: () => {},
+  apiClient: new TownsServiceClient(),
+  townMessageChain: new MessageChain(),
+  proximityMessageChain: new MessageChain(),
+  directMessageChains: {},
+});
+
+describe('reducer', () => {
+  const player1Id = '123';
+  const player2Id = '456';
+  const directMessageId = '123:456';
+
+  describe('messageReceived', () => {
+    it('adds new messages to existing town message chain', () => {
+      const messageToTest = createMessageForTesting(MessageType.TownMessage, nanoid());
+      const message2ToTest = createMessageForTesting(MessageType.TownMessage, nanoid());
+      const firstState = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      expect(firstState.townMessageChain.messages.length).toBe(1);
+      expect(firstState.townMessageChain.messages).toContain(messageToTest);
+      const secondState = appStateReducer(firstState, {
+        action: 'messageReceived',
+        message: message2ToTest,
+      });
+      expect(secondState.townMessageChain.messages.length).toBe(2);
+    });
+
+    it('adds new messages to existing proximity message chain', () => {
+      const messageToTest = createMessageForTesting(MessageType.ProximityMessage, nanoid());
+      const message2ToTest = createMessageForTesting(MessageType.ProximityMessage, nanoid());
+      const firstState = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      expect(firstState.proximityMessageChain.messages.length).toBe(1);
+      expect(firstState.proximityMessageChain.messages).toContain(messageToTest);
+      const secondState = appStateReducer(firstState, {
+        action: 'messageReceived',
+        message: message2ToTest,
+      });
+      expect(secondState.proximityMessageChain.messages.length).toBe(2);
+    });
+
+    it('creates new message chain for direct message', () => {
+      const messageToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+      const firstState = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      const messageChainToCheck = firstState.directMessageChains[directMessageId];
+      expect(messageChainToCheck.messages.length).toBe(1);
+      expect(messageChainToCheck.messages).toContain(messageToTest);
+    });
+    it('adds message to existing chain for direct message', () => {
+      const messageToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+      const message2ToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+      const firstState = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      expect(firstState.directMessageChains[directMessageId].messages.length).toBe(1);
+      const secondState = appStateReducer(firstState, {
+        action: 'messageReceived',
+        message: message2ToTest,
+      });
+      expect(secondState.directMessageChains[directMessageId].messages.length).toBe(2);
+    });
+  });
+  describe('playerDisconnected', () => {
+    it('sets direct messages with that player to inactive', () => {
+      const messageToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+      const firstState = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+
+      expect(firstState.directMessageChains[directMessageId].isActive).toBe(true);
+
+      const secondState = appStateReducer(firstState, {
+        action: 'playerDisconnect',
+        player: new Player(player2Id, 'test user', {
+          x: 0,
+          y: 0,
+          rotation: 'front',
+          moving: false,
+        }),
+      });
+
+      expect(secondState.directMessageChains[directMessageId].isActive).toBe(false);
+    });
+  });
+});

--- a/frontend/src/reducer.test.ts
+++ b/frontend/src/reducer.test.ts
@@ -105,6 +105,43 @@ describe('reducer', () => {
       });
       expect(secondState.directMessageChains[directMessageId].messages.length).toBe(2);
     });
+
+    it('adds message to correct chain for direct message', () => {
+      const messageToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+      const messageInSecondChain = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        '789',
+      );
+      const messageInFirstChain = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+      
+      const firstState = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      expect(firstState.directMessageChains[directMessageId].messages.length).toBe(1);
+
+      const secondState = appStateReducer(firstState, {
+        action: 'messageReceived',
+        message: messageInSecondChain,
+      });
+      expect(secondState.directMessageChains['123:789'].messages.length).toBe(1);
+
+      const thirdState = appStateReducer(secondState, {
+        action: 'messageReceived',
+        message: messageInFirstChain,
+      });
+      expect(thirdState.directMessageChains['123:789'].messages.length).toBe(1);
+      expect(thirdState.directMessageChains[directMessageId].messages.length).toBe(2);
+    });
   });
   describe('playerDisconnected', () => {
     it('sets direct messages with that player to inactive', () => {

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -1,0 +1,189 @@
+import { Socket } from 'socket.io-client';
+import './App.css';
+import MessageChain, { Message, MessageType } from './classes/MessageChain';
+import Player, { UserLocation } from './classes/Player';
+import TownsServiceClient from './classes/TownsServiceClient';
+import { CoveyAppState, NearbyPlayers } from './CoveyTypes';
+
+export type CoveyAppUpdate =
+  | {
+      action: 'doConnect';
+      data: {
+        userName: string;
+        townFriendlyName: string;
+        townID: string;
+        townIsPubliclyListed: boolean;
+        sessionToken: string;
+        myPlayerID: string;
+        socket: Socket;
+        players: Player[];
+        emitMovement: (location: UserLocation) => void;
+      };
+    }
+  | { action: 'addPlayer'; player: Player }
+  | { action: 'playerMoved'; player: Player }
+  | { action: 'playerDisconnect'; player: Player }
+  | { action: 'weMoved'; location: UserLocation }
+  | { action: 'disconnect' }
+  | { action: 'messageReceived'; message: Message };
+
+export function defaultAppState(): CoveyAppState {
+  return {
+    nearbyPlayers: { nearbyPlayers: [] },
+    players: [],
+    myPlayerID: '',
+    currentTownFriendlyName: '',
+    currentTownID: '',
+    currentTownIsPubliclyListed: false,
+    sessionToken: '',
+    userName: '',
+    socket: null,
+    currentLocation: {
+      x: 0,
+      y: 0,
+      rotation: 'front',
+      moving: false,
+    },
+    emitMovement: () => {},
+    apiClient: new TownsServiceClient(),
+    townMessageChain: new MessageChain(),
+    proximityMessageChain: new MessageChain(),
+    directMessageChains: {},
+  };
+}
+export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): CoveyAppState {
+  const nextState = {
+    sessionToken: state.sessionToken,
+    currentTownFriendlyName: state.currentTownFriendlyName,
+    currentTownID: state.currentTownID,
+    currentTownIsPubliclyListed: state.currentTownIsPubliclyListed,
+    myPlayerID: state.myPlayerID,
+    players: state.players,
+    currentLocation: state.currentLocation,
+    nearbyPlayers: state.nearbyPlayers,
+    userName: state.userName,
+    socket: state.socket,
+    emitMovement: state.emitMovement,
+    apiClient: state.apiClient,
+    townMessageChain: state.townMessageChain,
+    proximityMessageChain: state.proximityMessageChain,
+    directMessageChains: state.directMessageChains,
+  };
+
+  function calculateNearbyPlayers(players: Player[], currentLocation: UserLocation) {
+    const isWithinCallRadius = (p: Player, location: UserLocation) => {
+      if (p.location && location) {
+        const dx = p.location.x - location.x;
+        const dy = p.location.y - location.y;
+        const d = Math.sqrt(dx * dx + dy * dy);
+        return d < 80;
+      }
+      return false;
+    };
+    return { nearbyPlayers: players.filter(p => isWithinCallRadius(p, currentLocation)) };
+  }
+
+  function samePlayers(a1: NearbyPlayers, a2: NearbyPlayers) {
+    if (a1.nearbyPlayers.length !== a2.nearbyPlayers.length) return false;
+    const ids1 = a1.nearbyPlayers.map(p => p.id).sort();
+    const ids2 = a2.nearbyPlayers.map(p => p.id).sort();
+    return !ids1.some((val, idx) => val !== ids2[idx]);
+  }
+
+  let updatePlayer;
+  let directMessageIdToInactivate;
+  let directMessageChainToInactivate;
+  let directMessageChainToUpdate;
+  switch (update.action) {
+    case 'doConnect':
+      nextState.sessionToken = update.data.sessionToken;
+      nextState.myPlayerID = update.data.myPlayerID;
+      nextState.currentTownFriendlyName = update.data.townFriendlyName;
+      nextState.currentTownID = update.data.townID;
+      nextState.currentTownIsPubliclyListed = update.data.townIsPubliclyListed;
+      nextState.userName = update.data.userName;
+      nextState.emitMovement = update.data.emitMovement;
+      nextState.socket = update.data.socket;
+      nextState.players = update.data.players;
+      break;
+    case 'addPlayer':
+      nextState.players = nextState.players.concat([update.player]);
+      break;
+    case 'playerMoved':
+      updatePlayer = nextState.players.find(p => p.id === update.player.id);
+      if (updatePlayer) {
+        updatePlayer.location = update.player.location;
+      } else {
+        nextState.players = nextState.players.concat([update.player]);
+      }
+      nextState.nearbyPlayers = calculateNearbyPlayers(
+        nextState.players,
+        nextState.currentLocation,
+      );
+      if (samePlayers(nextState.nearbyPlayers, state.nearbyPlayers)) {
+        nextState.nearbyPlayers = state.nearbyPlayers;
+      }
+      break;
+    case 'weMoved':
+      nextState.currentLocation = update.location;
+      nextState.nearbyPlayers = calculateNearbyPlayers(
+        nextState.players,
+        nextState.currentLocation,
+      );
+      if (samePlayers(nextState.nearbyPlayers, state.nearbyPlayers)) {
+        nextState.nearbyPlayers = state.nearbyPlayers;
+      }
+
+      break;
+    case 'playerDisconnect':
+      nextState.players = nextState.players.filter(player => player.id !== update.player.id);
+      nextState.nearbyPlayers = calculateNearbyPlayers(
+        nextState.players,
+        nextState.currentLocation,
+      );
+      if (samePlayers(nextState.nearbyPlayers, state.nearbyPlayers)) {
+        nextState.nearbyPlayers = state.nearbyPlayers;
+      }
+
+      // deactivate chats that include that player
+      directMessageIdToInactivate = [nextState.myPlayerID, update.player.id].sort().join(':');
+      directMessageChainToInactivate = nextState.directMessageChains[directMessageIdToInactivate];
+
+      if (directMessageChainToInactivate) {
+        directMessageChainToInactivate.isActive = false;
+        nextState.directMessageChains[directMessageIdToInactivate] = directMessageChainToInactivate;
+      }
+
+      break;
+    case 'disconnect':
+      state.socket?.disconnect();
+      return defaultAppState();
+    case 'messageReceived':
+      switch (update.message.type) {
+        case MessageType.TownMessage:
+          nextState.townMessageChain = nextState.townMessageChain.addMessage(update.message);
+          break;
+        case MessageType.ProximityMessage:
+          nextState.proximityMessageChain = nextState.proximityMessageChain.addMessage(
+            update.message,
+          );
+          break;
+        default:
+          if (update.message.directMessageId) {
+            directMessageChainToUpdate =
+              nextState.directMessageChains[update.message.directMessageId];
+            nextState.directMessageChains[
+              update.message.directMessageId
+            ] = directMessageChainToUpdate
+              ? directMessageChainToUpdate.addMessage(update.message)
+              : new MessageChain(update.message);
+          }
+          break;
+      }
+      break;
+    default:
+      throw new Error('Unexpected state request');
+  }
+
+  return nextState;
+}


### PR DESCRIPTION
Apologies for the massive PR, but there's a ton of our functionality crammed in here:

- Implements `MessageChain` in the frontend
- Implements receiving and storing messages from the socket
- Implements marking direct messages as inactive when a player in that message disconnects
- Moves the reducer into its own file so that it can be tested
- Ensures that components with css imports won't crash the jest tests

Now all we need to do to get our chat to hook up to the front end is just send the messages to the correct sockets from the controller. After that, we'll just need to finish the React components and prepare the message `POST` endpoint.

**IMPORTANT**: view this with whitespace changes hidden, and ignore all changes to `WorldMap`, `TownSelection`, and `TownSettings`, most of it's just my linter automatically cleaning the code from the profs