### PR TITLE
feat: Emit socket event to all listeners when TownWideMessage received

### DIFF
--- a/services/roomService/src/client/CoveyTownsSocket.test.ts
+++ b/services/roomService/src/client/CoveyTownsSocket.test.ts
@@ -108,6 +108,25 @@ describe('TownServiceApiSocket', () => {
     expect((await newPlayerPromise2)._userName).toBe(newJoinerName);
 
   });
+
+  // it('Informs all clients when a new message is sent', async () => {
+  //   const town = await createTownForTesting();
+  //   const joinData = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});
+  //   const joinData2 = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});
+  //   const {socketConnected, newPlayerJoined} = TestUtils.createSocketClient(server, joinData.coveySessionToken, town.coveyTownID);
+  //   const {
+  //     socketConnected: connectPromise2,
+  //     newPlayerJoined: newPlayerPromise2,
+  //   } = TestUtils.createSocketClient(server, joinData2.coveySessionToken, town.coveyTownID);
+  //   await Promise.all([socketConnected, connectPromise2]);
+  //   const newJoinerName = nanoid();
+
+  //   await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: newJoinerName});
+  //   expect((await newPlayerJoined)._userName).toBe(newJoinerName);
+  //   expect((await newPlayerPromise2)._userName).toBe(newJoinerName);
+
+  // });
+  
   it('Informs all players when a player disconnects', async () => {
     const town = await createTownForTesting();
     const joinData = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});

--- a/services/roomService/src/client/CoveyTownsSocket.test.ts
+++ b/services/roomService/src/client/CoveyTownsSocket.test.ts
@@ -7,7 +7,7 @@ import { promisify } from 'util';
 import io from 'socket.io';
 import * as TestUtils from './TestUtils';
 
-import { UserLocation } from '../CoveyTypes';
+import { MessageType, UserLocation } from '../CoveyTypes';
 import TownsServiceClient from './TownsServiceClient';
 import addTownRoutes from '../router/towns';
 
@@ -108,24 +108,6 @@ describe('TownServiceApiSocket', () => {
     expect((await newPlayerPromise2)._userName).toBe(newJoinerName);
 
   });
-
-  // it('Informs all clients when a new message is sent', async () => {
-  //   const town = await createTownForTesting();
-  //   const joinData = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});
-  //   const joinData2 = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});
-  //   const {socketConnected, newPlayerJoined} = TestUtils.createSocketClient(server, joinData.coveySessionToken, town.coveyTownID);
-  //   const {
-  //     socketConnected: connectPromise2,
-  //     newPlayerJoined: newPlayerPromise2,
-  //   } = TestUtils.createSocketClient(server, joinData2.coveySessionToken, town.coveyTownID);
-  //   await Promise.all([socketConnected, connectPromise2]);
-  //   const newJoinerName = nanoid();
-
-  //   await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: newJoinerName});
-  //   expect((await newPlayerJoined)._userName).toBe(newJoinerName);
-  //   expect((await newPlayerPromise2)._userName).toBe(newJoinerName);
-
-  // });
   
   it('Informs all players when a player disconnects', async () => {
     const town = await createTownForTesting();

--- a/services/roomService/src/client/TestUtils.ts
+++ b/services/roomService/src/client/TestUtils.ts
@@ -46,7 +46,6 @@ export function createSocketClient(server: http.Server, sessionToken: string, co
   playerMoved: Promise<RemoteServerPlayer>,
   newPlayerJoined: Promise<RemoteServerPlayer>,
   playerDisconnected: Promise<RemoteServerPlayer>,
-  messageReceived: Promise<Message>,
 } {
   const address = server.address() as AddressInfo;
   const socket = io(`http://localhost:${address.port}`, {
@@ -68,12 +67,7 @@ export function createSocketClient(server: http.Server, sessionToken: string, co
       resolve(player);
     });
   });
-  const messageReceivedPromise = new Promise<Message>((resolve) => {
-    socket.on('messageReceived', (message: Message) => {
-      resolve(message);
-    });
-  });
-  const newPlayerPromise = new Promise<RemoteServerPlayer>((resolve) => {
+  const newPlayerPromise = new Promise<RemoteServerPlayer>((resolve) => { 
     socket.on('newPlayer', (player: RemoteServerPlayer) => {
       resolve(player);
     });
@@ -91,7 +85,6 @@ export function createSocketClient(server: http.Server, sessionToken: string, co
     playerMoved: playerMovedPromise,
     newPlayerJoined: newPlayerPromise,
     playerDisconnected: playerDisconnectPromise,
-    messageReceived: messageReceivedPromise,
   };
 }
 export function setSessionTokenAndTownID(coveyTownID: string, sessionToken: string, socket: ServerSocket):void {

--- a/services/roomService/src/lib/CoveyTownController.test.ts
+++ b/services/roomService/src/lib/CoveyTownController.test.ts
@@ -1,15 +1,15 @@
-import {nanoid} from 'nanoid';
-import {mock, mockReset} from 'jest-mock-extended';
-import {Socket} from 'socket.io';
-import TwilioVideo from './TwilioVideo';
-import Player from '../types/Player';
-import CoveyTownController from './CoveyTownController';
-import CoveyTownListener from '../types/CoveyTownListener';
-import {UserLocation} from '../CoveyTypes';
-import PlayerSession from '../types/PlayerSession';
-import {townSubscriptionHandler} from '../requestHandlers/CoveyTownRequestHandlers';
-import CoveyTownsStore from './CoveyTownsStore';
+import { mock, mockReset } from 'jest-mock-extended';
+import { nanoid } from 'nanoid';
+import { Socket } from 'socket.io';
 import * as TestUtils from '../client/TestUtils';
+import { MessageType, UserLocation } from '../CoveyTypes';
+import { townSubscriptionHandler } from '../requestHandlers/CoveyTownRequestHandlers';
+import CoveyTownListener from '../types/CoveyTownListener';
+import Player from '../types/Player';
+import PlayerSession from '../types/PlayerSession';
+import CoveyTownController from './CoveyTownController';
+import CoveyTownsStore from './CoveyTownsStore';
+import TwilioVideo from './TwilioVideo';
 
 jest.mock('./TwilioVideo');
 
@@ -33,27 +33,32 @@ describe('CoveyTownController', () => {
   beforeEach(() => {
     mockGetTokenForTown.mockClear();
   });
-  it('constructor should set the friendlyName property', () => { // Included in handout
+  it('constructor should set the friendlyName property', () => {
+    // Included in handout
     const townName = `FriendlyNameTest-${nanoid()}`;
     const townController = new CoveyTownController(townName, false);
-    expect(townController.friendlyName)
-      .toBe(townName);
+    expect(townController.friendlyName).toBe(townName);
   });
-  describe('addPlayer', () => { // Included in handout
-    it('should use the coveyTownID and player ID properties when requesting a video token',
-      async () => {
-        const townName = `FriendlyNameTest-${nanoid()}`;
-        const townController = new CoveyTownController(townName, false);
-        const newPlayerSession = await townController.addPlayer(new Player(nanoid()));
-        expect(mockGetTokenForTown).toBeCalledTimes(1);
-        expect(mockGetTokenForTown).toBeCalledWith(townController.coveyTownID, newPlayerSession.player.id);
-      });
+  describe('addPlayer', () => {
+    // Included in handout
+    it('should use the coveyTownID and player ID properties when requesting a video token', async () => {
+      const townName = `FriendlyNameTest-${nanoid()}`;
+      const townController = new CoveyTownController(townName, false);
+      const newPlayerSession = await townController.addPlayer(new Player(nanoid()));
+      expect(mockGetTokenForTown).toBeCalledTimes(1);
+      expect(mockGetTokenForTown).toBeCalledWith(
+        townController.coveyTownID,
+        newPlayerSession.player.id,
+      );
+    });
   });
   describe('town listeners and events', () => {
     let testingTown: CoveyTownController;
-    const mockListeners = [mock<CoveyTownListener>(),
+    const mockListeners = [
       mock<CoveyTownListener>(),
-      mock<CoveyTownListener>()];
+      mock<CoveyTownListener>(),
+      mock<CoveyTownListener>(),
+    ];
     beforeEach(() => {
       const townName = `town listeners and events tests ${nanoid()}`;
       testingTown = new CoveyTownController(townName, false);
@@ -73,7 +78,9 @@ describe('CoveyTownController', () => {
 
       mockListeners.forEach(listener => testingTown.addTownListener(listener));
       testingTown.destroySession(session);
-      mockListeners.forEach(listener => expect(listener.onPlayerDisconnected).toBeCalledWith(player));
+      mockListeners.forEach(listener =>
+        expect(listener.onPlayerDisconnected).toBeCalledWith(player),
+      );
     });
     it('should notify added listeners of new players when addPlayer is called', async () => {
       mockListeners.forEach(listener => testingTown.addTownListener(listener));
@@ -81,7 +88,14 @@ describe('CoveyTownController', () => {
       const player = new Player('test player');
       await testingTown.addPlayer(player);
       mockListeners.forEach(listener => expect(listener.onPlayerJoined).toBeCalledWith(player));
+    });
+    it('should notify all listeners of a new message when a TownMessage is sent', async () => {
+      mockListeners.forEach(listener => testingTown.addTownListener(listener));
+      const player = new Player('test player');
+      const message = TestUtils.createMessageForTesting(MessageType.TownMessage, player.id);
 
+      testingTown.receiveMessage(message);
+      mockListeners.forEach(listener => expect(listener.onMessageReceived).toBeCalledWith(message));
     });
     it('should notify added listeners that the town is destroyed when disconnectAllPlayers is called', async () => {
       const player = new Player('test player');
@@ -90,7 +104,6 @@ describe('CoveyTownController', () => {
       mockListeners.forEach(listener => testingTown.addTownListener(listener));
       testingTown.disconnectAllPlayers();
       mockListeners.forEach(listener => expect(listener.onTownDestroyed).toBeCalled());
-
     });
     it('should not notify removed listeners of player movement when updatePlayerLocation is called', async () => {
       const player = new Player('test player');
@@ -112,7 +125,6 @@ describe('CoveyTownController', () => {
       testingTown.removeTownListener(listenerRemoved);
       testingTown.destroySession(session);
       expect(listenerRemoved.onPlayerDisconnected).not.toBeCalled();
-
     });
     it('should not notify removed listeners of new players when addPlayer is called', async () => {
       const player = new Player('test player');
@@ -134,7 +146,6 @@ describe('CoveyTownController', () => {
       testingTown.removeTownListener(listenerRemoved);
       testingTown.disconnectAllPlayers();
       expect(listenerRemoved.onTownDestroyed).not.toBeCalled();
-
     });
   });
   describe('townSubscriptionHandler', () => {
@@ -161,26 +172,41 @@ describe('CoveyTownController', () => {
     });
     describe('with a valid session token', () => {
       it('should add a town listener, which should emit "newPlayer" to the socket when a player joins', async () => {
-        TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+        TestUtils.setSessionTokenAndTownID(
+          testingTown.coveyTownID,
+          session.sessionToken,
+          mockSocket,
+        );
         townSubscriptionHandler(mockSocket);
         await testingTown.addPlayer(player);
         expect(mockSocket.emit).toBeCalledWith('newPlayer', player);
       });
       it('should add a town listener, which should emit "playerMoved" to the socket when a player moves', async () => {
-        TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+        TestUtils.setSessionTokenAndTownID(
+          testingTown.coveyTownID,
+          session.sessionToken,
+          mockSocket,
+        );
         townSubscriptionHandler(mockSocket);
         testingTown.updatePlayerLocation(player, generateTestLocation());
         expect(mockSocket.emit).toBeCalledWith('playerMoved', player);
-
       });
       it('should add a town listener, which should emit "playerDisconnect" to the socket when a player disconnects', async () => {
-        TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+        TestUtils.setSessionTokenAndTownID(
+          testingTown.coveyTownID,
+          session.sessionToken,
+          mockSocket,
+        );
         townSubscriptionHandler(mockSocket);
         testingTown.destroySession(session);
         expect(mockSocket.emit).toBeCalledWith('playerDisconnect', player);
       });
       it('should add a town listener, which should emit "townClosing" to the socket and disconnect it when disconnectAllPlayers is called', async () => {
-        TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+        TestUtils.setSessionTokenAndTownID(
+          testingTown.coveyTownID,
+          session.sessionToken,
+          mockSocket,
+        );
         townSubscriptionHandler(mockSocket);
         testingTown.disconnectAllPlayers();
         expect(mockSocket.emit).toBeCalledWith('townClosing');
@@ -188,7 +214,11 @@ describe('CoveyTownController', () => {
       });
       describe('when a socket disconnect event is fired', () => {
         it('should remove the town listener for that socket, and stop sending events to it', async () => {
-          TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+          TestUtils.setSessionTokenAndTownID(
+            testingTown.coveyTownID,
+            session.sessionToken,
+            mockSocket,
+          );
           townSubscriptionHandler(mockSocket);
 
           // find the 'disconnect' event handler for the socket, which should have been registered after the socket was connected
@@ -203,7 +233,11 @@ describe('CoveyTownController', () => {
           }
         });
         it('should destroy the session corresponding to that socket', async () => {
-          TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+          TestUtils.setSessionTokenAndTownID(
+            testingTown.coveyTownID,
+            session.sessionToken,
+            mockSocket,
+          );
           townSubscriptionHandler(mockSocket);
 
           // find the 'disconnect' event handler for the socket, which should have been registered after the socket was connected
@@ -211,22 +245,31 @@ describe('CoveyTownController', () => {
           if (disconnectHandler && disconnectHandler[1]) {
             disconnectHandler[1]();
             mockReset(mockSocket);
-            TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+            TestUtils.setSessionTokenAndTownID(
+              testingTown.coveyTownID,
+              session.sessionToken,
+              mockSocket,
+            );
             townSubscriptionHandler(mockSocket);
             expect(mockSocket.disconnect).toHaveBeenCalledWith(true);
           } else {
             fail('No disconnect handler registered');
           }
-
         });
       });
       it('should forward playerMovement events from the socket to subscribed listeners', async () => {
-        TestUtils.setSessionTokenAndTownID(testingTown.coveyTownID, session.sessionToken, mockSocket);
+        TestUtils.setSessionTokenAndTownID(
+          testingTown.coveyTownID,
+          session.sessionToken,
+          mockSocket,
+        );
         townSubscriptionHandler(mockSocket);
         const mockListener = mock<CoveyTownListener>();
         testingTown.addTownListener(mockListener);
         // find the 'playerMovement' event handler for the socket, which should have been registered after the socket was connected
-        const playerMovementHandler = mockSocket.on.mock.calls.find(call => call[0] === 'playerMovement');
+        const playerMovementHandler = mockSocket.on.mock.calls.find(
+          call => call[0] === 'playerMovement',
+        );
         if (playerMovementHandler && playerMovementHandler[1]) {
           const newLocation = generateTestLocation();
           player.location = newLocation;

--- a/services/roomService/src/lib/CoveyTownController.ts
+++ b/services/roomService/src/lib/CoveyTownController.ts
@@ -120,6 +120,8 @@ export default class CoveyTownController {
     this._listeners.forEach((listener) => listener.onPlayerMoved(player));
   }
 
+  
+
   /**
    * Subscribe to events from this town. Callers should make sure to
    * unsubscribe when they no longer want those events by calling removeTownListener

--- a/services/roomService/src/lib/CoveyTownController.ts
+++ b/services/roomService/src/lib/CoveyTownController.ts
@@ -1,5 +1,5 @@
 import { customAlphabet, nanoid } from 'nanoid';
-import { UserLocation } from '../CoveyTypes';
+import { Message, MessageType, UserLocation } from '../CoveyTypes';
 import CoveyTownListener from '../types/CoveyTownListener';
 import Player from '../types/Player';
 import PlayerSession from '../types/PlayerSession';
@@ -120,7 +120,24 @@ export default class CoveyTownController {
     this._listeners.forEach((listener) => listener.onPlayerMoved(player));
   }
 
-  
+  /**
+   * Sends an incoming message to relevant listeners based on the message's type:
+   * If TownMessage, sends to all listeners
+   * If ProximityMessage, sends only to listeners near the message's location
+   * If DirectMessage, only to listeners involved in the conversation
+   * @param message The incoming message
+   */
+  receiveMessage(message: Message): void {
+    switch (message.type) {
+      case MessageType.TownMessage:
+        this._listeners.forEach((listener) => listener.onMessageReceived(message));
+        break;
+      default:
+        break;
+    }
+  }
+
+
 
   /**
    * Subscribe to events from this town. Callers should make sure to

--- a/services/roomService/src/lib/CoveyTownsStore.test.ts
+++ b/services/roomService/src/lib/CoveyTownsStore.test.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import CoveyTownsStore from './CoveyTownsStore';
 import CoveyTownListener from '../types/CoveyTownListener';
 import Player from '../types/Player';
+import { Message } from '../CoveyTypes';
 
 const mockCoveyListenerTownDestroyed = jest.fn();
 const mockCoveyListenerOtherFns = jest.fn();
@@ -20,6 +21,12 @@ function mockCoveyListener(): CoveyTownListener {
     onPlayerJoined(newPlayer: Player) {
       mockCoveyListenerOtherFns(newPlayer);
     },
+    onMessageReceived(message: Message): void {
+      mockCoveyListenerOtherFns(message);
+    },
+    getAssociatedPlayer(): Player {
+      return new Player('test');
+    }
   };
 }
 

--- a/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
+++ b/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
@@ -175,7 +175,7 @@ export async function townUpdateHandler(requestData: TownUpdateRequest): Promise
  *
  * @param socket the Socket object that we will use to communicate with the player
  */
-function townSocketAdapter(socket: Socket): CoveyTownListener {
+function townSocketAdapter(socket: Socket, player: Player): CoveyTownListener {
   return {
     onPlayerMoved(movedPlayer: Player) {
       socket.emit('playerMoved', movedPlayer);
@@ -189,6 +189,9 @@ function townSocketAdapter(socket: Socket): CoveyTownListener {
     onTownDestroyed() {
       socket.emit('townClosing');
       socket.disconnect(true);
+    },
+    getAssociatedPlayer() {
+      return player
     },
   };
 }
@@ -216,7 +219,7 @@ export function townSubscriptionHandler(socket: Socket): void {
 
   // Create an adapter that will translate events from the CoveyTownController into
   // events that the socket protocol knows about
-  const listener = townSocketAdapter(socket);
+  const listener = townSocketAdapter(socket, s.player);
   townController.addTownListener(listener);
 
   // Register an event listener for the client socket: if the client disconnects,

--- a/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
+++ b/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { Socket } from 'socket.io';
 import Player from '../types/Player';
-import { CoveyTownList, UserLocation } from '../CoveyTypes';
+import { CoveyTownList, Message, UserLocation } from '../CoveyTypes';
 import CoveyTownListener from '../types/CoveyTownListener';
 import CoveyTownsStore from '../lib/CoveyTownsStore';
 
@@ -189,6 +189,9 @@ function townSocketAdapter(socket: Socket, player: Player): CoveyTownListener {
     onTownDestroyed() {
       socket.emit('townClosing');
       socket.disconnect(true);
+    },
+    onMessageReceived(message: Message) {
+      socket.emit('messageReceived', message);
     },
     getAssociatedPlayer() {
       return player

--- a/services/roomService/src/types/CoveyTownListener.ts
+++ b/services/roomService/src/types/CoveyTownListener.ts
@@ -1,9 +1,11 @@
+import { Message } from '../CoveyTypes';
 import Player from './Player';
 
 /**
  * A listener for player-related events in each town
  */
 export default interface CoveyTownListener {
+  
   /**
    * Called when a player joins a town
    * @param newPlayer the new player
@@ -26,6 +28,12 @@ export default interface CoveyTownListener {
    * Called when a town is destroyed, causing all players to disconnect
    */
   onTownDestroyed(): void;
+
+  /**
+   * Called when a player sends a message
+   * @param message The incoming message
+   */
+  onMessageReceived(message: Message): void;
 
   /**
    * Gets the player associated with this listener

--- a/services/roomService/src/types/CoveyTownListener.ts
+++ b/services/roomService/src/types/CoveyTownListener.ts
@@ -26,4 +26,9 @@ export default interface CoveyTownListener {
    * Called when a town is destroyed, causing all players to disconnect
    */
   onTownDestroyed(): void;
+
+  /**
+   * Gets the player associated with this listener
+   */
+  getAssociatedPlayer(): Player;
 }


### PR DESCRIPTION
- Add new `onMessageReceived` handler to `townSocketAdapter` that emits a socket event 
- Adds `getAssociatedPlayer` method to `townSocketAdapter` that will return the Player associated with a listener. This will be necessary to implement proximity chats and DMs
- Add `receiveMessage` method to `CoveyTownController`, which will notify all listeners when a town-wide message is received
- Added test to `CoveyTownController.test` to test that listeners will be triggered when `receiveMessage` is called. We can't add a socket test in `CoveyTownsSocket.test` until we have the code that directly receives the front end message (either the REST endpoint or `socket.on` function in `townSubscriptionHandler`