### PR TITLE
feat: Add socket emission to front end 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,70 +31,10 @@ import WorldMap from './components/world/WorldMap';
 import CoveyAppContext from './contexts/CoveyAppContext';
 import NearbyPlayersContext from './contexts/NearbyPlayersContext';
 import VideoContext from './contexts/VideoContext';
+import { GameController } from './GameController'
 import { appStateReducer, CoveyAppUpdate, defaultAppState } from './reducer';
 
-async function GameController(
-  initData: TownJoinResponse,
-  dispatchAppUpdate: (update: CoveyAppUpdate) => void,
-) {
-  // Now, set up the game sockets
-  const gamePlayerID = initData.coveyUserID;
-  const sessionToken = initData.coveySessionToken;
-  const url = process.env.REACT_APP_TOWNS_SERVICE_URL;
-  assert(url);
-  const video = Video.instance();
-  assert(video);
-  const roomName = video.townFriendlyName;
-  assert(roomName);
 
-  const socket = io(url, { auth: { token: sessionToken, coveyTownID: video.coveyTownID } });
-  socket.on('newPlayer', (player: ServerPlayer) => {
-    dispatchAppUpdate({
-      action: 'addPlayer',
-      player: Player.fromServerPlayer(player),
-    });
-  });
-  socket.on('playerMoved', (player: ServerPlayer) => {
-    if (player._id !== gamePlayerID) {
-      dispatchAppUpdate({ action: 'playerMoved', player: Player.fromServerPlayer(player) });
-    }
-  });
-  socket.on('playerDisconnect', (player: ServerPlayer) => {
-    dispatchAppUpdate({ action: 'playerDisconnect', player: Player.fromServerPlayer(player) });
-  });
-  socket.on('disconnect', () => {
-    dispatchAppUpdate({ action: 'disconnect' });
-  });
-  socket.on('messageReceived', (message: Message) => {
-    dispatchAppUpdate({ action: 'messageReceived', message });
-  });
-  const emitMovement = (location: UserLocation) => {
-    socket.emit('playerMovement', location);
-    dispatchAppUpdate({ action: 'weMoved', location });
-  };
-  const emitMessage = (message: Message) => {
-    socket.emit('messageSent', message);
-    // don't need to update the app with the sent message, the socket will emit messageReceived back to us
-    // and we update it then  
-  };
-
-  dispatchAppUpdate({
-    action: 'doConnect',
-    data: {
-      sessionToken,
-      userName: video.userName,
-      townFriendlyName: roomName,
-      townID: video.coveyTownID,
-      myPlayerID: gamePlayerID,
-      townIsPubliclyListed: video.isPubliclyListed,
-      emitMovement,
-      emitMessage,
-      socket,
-      players: initData.currentPlayers.map(sp => Player.fromServerPlayer(sp)),
-    },
-  });
-  return true;
-}
 
 function App(props: { setOnDisconnect: Dispatch<SetStateAction<Callback | undefined>> }) {
   const [appState, dispatchAppUpdate] = useReducer(appStateReducer, defaultAppState());

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { MuiThemeProvider } from '@material-ui/core/styles';
-import assert from 'assert';
 import React, {
   Dispatch,
   SetStateAction,
@@ -11,10 +10,7 @@ import React, {
   useState,
 } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { io } from 'socket.io-client';
 import './App.css';
-import { Message } from './classes/MessageChain';
-import Player, { ServerPlayer, UserLocation } from './classes/Player';
 import { TownJoinResponse } from './classes/TownsServiceClient';
 import Video from './classes/Video/Video';
 import ChatSidebar from './components/Chat/ChatSidebar';
@@ -31,8 +27,8 @@ import WorldMap from './components/world/WorldMap';
 import CoveyAppContext from './contexts/CoveyAppContext';
 import NearbyPlayersContext from './contexts/NearbyPlayersContext';
 import VideoContext from './contexts/VideoContext';
-import { GameController } from './GameController'
-import { appStateReducer, CoveyAppUpdate, defaultAppState } from './reducer';
+import GameController from './GameController'
+import { appStateReducer, defaultAppState } from './reducer';
 
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,6 +72,11 @@ async function GameController(
     socket.emit('playerMovement', location);
     dispatchAppUpdate({ action: 'weMoved', location });
   };
+  const emitMessage = (message: Message) => {
+    socket.emit('messageSent', message);
+    // don't need to update the app with the sent message, the socket will emit messageReceived back to us
+    // and we update it then  
+  };
 
   dispatchAppUpdate({
     action: 'doConnect',
@@ -83,6 +88,7 @@ async function GameController(
       myPlayerID: gamePlayerID,
       townIsPubliclyListed: video.isPubliclyListed,
       emitMovement,
+      emitMessage,
       socket,
       players: initData.currentPlayers.map(sp => Player.fromServerPlayer(sp)),
     },

--- a/frontend/src/CoveyTypes.ts
+++ b/frontend/src/CoveyTypes.ts
@@ -1,5 +1,5 @@
 import { Socket } from 'socket.io-client';
-import MessageChain, { MessageChainHash } from './classes/MessageChain';
+import MessageChain, { Message, MessageChainHash } from './classes/MessageChain';
 import Player, { UserLocation } from './classes/Player';
 import TownsServiceClient from './classes/TownsServiceClient';
 
@@ -30,6 +30,7 @@ export type CoveyAppState = {
   currentLocation: UserLocation;
   nearbyPlayers: NearbyPlayers;
   emitMovement: (location: UserLocation) => void;
+  emitMessage: (message: Message) => void;
   socket: Socket | null;
   apiClient: TownsServiceClient;
   townMessageChain: MessageChain;

--- a/frontend/src/GameController.tsx
+++ b/frontend/src/GameController.tsx
@@ -1,0 +1,70 @@
+import { assert } from "console";
+import { io } from "socket.io-client";
+import { Message } from "./classes/MessageChain";
+import Player, { ServerPlayer, UserLocation } from "./classes/Player";
+import { TownJoinResponse } from "./classes/TownsServiceClient";
+import Video from './classes/Video/Video';
+import { CoveyAppUpdate } from "./reducer";
+
+export async function GameController(
+    initData: TownJoinResponse,
+    dispatchAppUpdate: (update: CoveyAppUpdate) => void,
+  ) {
+    // Now, set up the game sockets
+    const gamePlayerID = initData.coveyUserID;
+    const sessionToken = initData.coveySessionToken;
+    const url = process.env.REACT_APP_TOWNS_SERVICE_URL;
+    assert(url);
+    const video = Video.instance();
+    assert(video);
+    const roomName = video.townFriendlyName;
+    assert(roomName);
+  
+    const socket = io(url, { auth: { token: sessionToken, coveyTownID: video.coveyTownID } });
+    socket.on('newPlayer', (player: ServerPlayer) => {
+      dispatchAppUpdate({
+        action: 'addPlayer',
+        player: Player.fromServerPlayer(player),
+      });
+    });
+    socket.on('playerMoved', (player: ServerPlayer) => {
+      if (player._id !== gamePlayerID) {
+        dispatchAppUpdate({ action: 'playerMoved', player: Player.fromServerPlayer(player) });
+      }
+    });
+    socket.on('playerDisconnect', (player: ServerPlayer) => {
+      dispatchAppUpdate({ action: 'playerDisconnect', player: Player.fromServerPlayer(player) });
+    });
+    socket.on('disconnect', () => {
+      dispatchAppUpdate({ action: 'disconnect' });
+    });
+    socket.on('messageReceived', (message: Message) => {
+      dispatchAppUpdate({ action: 'messageReceived', message });
+    });
+    const emitMovement = (location: UserLocation) => {
+      socket.emit('playerMovement', location);
+      dispatchAppUpdate({ action: 'weMoved', location });
+    };
+    const emitMessage = (message: Message) => {
+      socket.emit('messageSent', message);
+      // don't need to update the app with the sent message, the socket will emit messageReceived back to us
+      // and we update it then  
+    };
+  
+    dispatchAppUpdate({
+      action: 'doConnect',
+      data: {
+        sessionToken,
+        userName: video.userName,
+        townFriendlyName: roomName,
+        townID: video.coveyTownID,
+        myPlayerID: gamePlayerID,
+        townIsPubliclyListed: video.isPubliclyListed,
+        emitMovement,
+        emitMessage,
+        socket,
+        players: initData.currentPlayers.map(sp => Player.fromServerPlayer(sp)),
+      },
+    });
+    return true;
+  }

--- a/frontend/src/GameController.tsx
+++ b/frontend/src/GameController.tsx
@@ -1,70 +1,70 @@
 import assert from 'assert';
-import { io } from "socket.io-client";
-import { Message } from "./classes/MessageChain";
-import Player, { ServerPlayer, UserLocation } from "./classes/Player";
-import { TownJoinResponse } from "./classes/TownsServiceClient";
+import { io } from 'socket.io-client';
+import { Message } from './classes/MessageChain';
+import Player, { ServerPlayer, UserLocation } from './classes/Player';
+import { TownJoinResponse } from './classes/TownsServiceClient';
 import Video from './classes/Video/Video';
-import { CoveyAppUpdate } from "./reducer";
+import { CoveyAppUpdate } from './reducer';
 
 export async function GameController(
-    initData: TownJoinResponse,
-    dispatchAppUpdate: (update: CoveyAppUpdate) => void,
-  ) {
-    // Now, set up the game sockets
-    const gamePlayerID = initData.coveyUserID;
-    const sessionToken = initData.coveySessionToken;
-    const url = process.env.REACT_APP_TOWNS_SERVICE_URL;
-    assert(url);
-    const video = Video.instance();
-    assert(video);
-    const roomName = video.townFriendlyName;
-    assert(roomName);
-  
-    const socket = io(url, { auth: { token: sessionToken, coveyTownID: video.coveyTownID } });
-    socket.on('newPlayer', (player: ServerPlayer) => {
-      dispatchAppUpdate({
-        action: 'addPlayer',
-        player: Player.fromServerPlayer(player),
-      });
-    });
-    socket.on('playerMoved', (player: ServerPlayer) => {
-      if (player._id !== gamePlayerID) {
-        dispatchAppUpdate({ action: 'playerMoved', player: Player.fromServerPlayer(player) });
-      }
-    });
-    socket.on('playerDisconnect', (player: ServerPlayer) => {
-      dispatchAppUpdate({ action: 'playerDisconnect', player: Player.fromServerPlayer(player) });
-    });
-    socket.on('disconnect', () => {
-      dispatchAppUpdate({ action: 'disconnect' });
-    });
-    socket.on('messageReceived', (message: Message) => {
-      dispatchAppUpdate({ action: 'messageReceived', message });
-    });
-    const emitMovement = (location: UserLocation) => {
-      socket.emit('playerMovement', location);
-      dispatchAppUpdate({ action: 'weMoved', location });
-    };
-    const emitMessage = (message: Message) => {
-      socket.emit('messageSent', message);
-      // don't need to update the app with the sent message, the socket will emit messageReceived back to us
-      // and we update it then  
-    };
-  
+  initData: TownJoinResponse,
+  dispatchAppUpdate: (update: CoveyAppUpdate) => void,
+) {
+  // Now, set up the game sockets
+  const gamePlayerID = initData.coveyUserID;
+  const sessionToken = initData.coveySessionToken;
+  const url = process.env.REACT_APP_TOWNS_SERVICE_URL;
+  assert(url);
+  const video = Video.instance();
+  assert(video);
+  const roomName = video.townFriendlyName;
+  assert(roomName);
+
+  const socket = io(url, { auth: { token: sessionToken, coveyTownID: video.coveyTownID } });
+  socket.on('newPlayer', (player: ServerPlayer) => {
     dispatchAppUpdate({
-      action: 'doConnect',
-      data: {
-        sessionToken,
-        userName: video.userName,
-        townFriendlyName: roomName,
-        townID: video.coveyTownID,
-        myPlayerID: gamePlayerID,
-        townIsPubliclyListed: video.isPubliclyListed,
-        emitMovement,
-        emitMessage,
-        socket,
-        players: initData.currentPlayers.map(sp => Player.fromServerPlayer(sp)),
-      },
+      action: 'addPlayer',
+      player: Player.fromServerPlayer(player),
     });
-    return true;
-  }
+  });
+  socket.on('playerMoved', (player: ServerPlayer) => {
+    if (player._id !== gamePlayerID) {
+      dispatchAppUpdate({ action: 'playerMoved', player: Player.fromServerPlayer(player) });
+    }
+  });
+  socket.on('playerDisconnect', (player: ServerPlayer) => {
+    dispatchAppUpdate({ action: 'playerDisconnect', player: Player.fromServerPlayer(player) });
+  });
+  socket.on('disconnect', () => {
+    dispatchAppUpdate({ action: 'disconnect' });
+  });
+  socket.on('messageReceived', (message: Message) => {
+    dispatchAppUpdate({ action: 'messageReceived', message });
+  });
+  const emitMovement = (location: UserLocation) => {
+    socket.emit('playerMovement', location);
+    dispatchAppUpdate({ action: 'weMoved', location });
+  };
+  const emitMessage = (message: Message) => {
+    socket.emit('messageSent', message);
+    // don't need to update the app with the sent message, the socket will emit messageReceived back to us
+    // and we update it then
+  };
+
+  dispatchAppUpdate({
+    action: 'doConnect',
+    data: {
+      sessionToken,
+      userName: video.userName,
+      townFriendlyName: roomName,
+      townID: video.coveyTownID,
+      myPlayerID: gamePlayerID,
+      townIsPubliclyListed: video.isPubliclyListed,
+      emitMovement,
+      emitMessage,
+      socket,
+      players: initData.currentPlayers.map(sp => Player.fromServerPlayer(sp)),
+    },
+  });
+  return true;
+}

--- a/frontend/src/GameController.tsx
+++ b/frontend/src/GameController.tsx
@@ -1,4 +1,4 @@
-import { assert } from "console";
+import assert from 'assert';
 import { io } from "socket.io-client";
 import { Message } from "./classes/MessageChain";
 import Player, { ServerPlayer, UserLocation } from "./classes/Player";

--- a/frontend/src/GameController.tsx
+++ b/frontend/src/GameController.tsx
@@ -6,10 +6,10 @@ import { TownJoinResponse } from './classes/TownsServiceClient';
 import Video from './classes/Video/Video';
 import { CoveyAppUpdate } from './reducer';
 
-export async function GameController(
+export default async function GameController(
   initData: TownJoinResponse,
   dispatchAppUpdate: (update: CoveyAppUpdate) => void,
-) {
+): Promise<boolean> {
   // Now, set up the game sockets
   const gamePlayerID = initData.coveyUserID;
   const sessionToken = initData.coveySessionToken;

--- a/frontend/src/components/Login/TownSelectionPart1.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart1.test.tsx
@@ -103,6 +103,7 @@ function wrappedTownSelection() {
             moving: false,
           },
           emitMovement: () => {},
+          emitMessage: () => {},
           apiClient: new TownsServiceClient(),
           townMessageChain: new MessageChain(),
           proximityMessageChain: new MessageChain(),

--- a/frontend/src/components/Login/TownSelectionPart2.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart2.test.tsx
@@ -100,6 +100,7 @@ function wrappedTownSelection() {
     },
     emitMovement: () => {
     },
+    emitMessage: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),

--- a/frontend/src/components/Login/TownSelectionPart3.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart3.test.tsx
@@ -100,6 +100,7 @@ function wrappedTownSelection() {
     },
     emitMovement: () => {
     },
+    emitMessage: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),

--- a/frontend/src/components/Login/TownSettings.test.tsx
+++ b/frontend/src/components/Login/TownSettings.test.tsx
@@ -53,6 +53,7 @@ function wrappedTownSettings() {
     },
     emitMovement: () => {
     },
+    emitMessage: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),

--- a/frontend/src/gameController.test.ts
+++ b/frontend/src/gameController.test.ts
@@ -1,46 +1,59 @@
-import * as socket from 'socket.io-client';
-
-import { Socket } from 'socket.io-client';
-import { mock, mockReset } from 'jest-mock-extended';
+import { mock } from 'jest-mock-extended';
 import { nanoid } from 'nanoid';
-import { GameController } from './GameController';
-import Video from './classes/Video/Video';
-import { createMessageForTesting } from './TestUtils';
 import { MessageType } from './classes/MessageChain';
+import Video from './classes/Video/Video';
+import { GameController } from './GameController';
+import { createMessageForTesting } from './TestUtils';
+
 jest.mock('./classes/Video/Video');
 
 jest.mock('socket.io-client', () => ({
-    io: () => ({
-      on: jest.fn(),
-      emit: jest.fn(),
-    }),
-  }));
+  io: () => ({
+    on: jest.fn(),
+    emit: jest.fn(),
+  }),
+}));
 
-  const mockVideoSetup = mock<Video>();
-    
-  Video.instance = () => {
-      return mockVideoSetup;
-  };
+const mockVideoSetup = mock<Video>();
 
-it('emits a message to the socket when a message is sent', async () => {
+Video.instance = () => {
+  return mockVideoSetup;
+};
+
+describe('game controller', () => {
+  // from https://stackoverflow.com/questions/48033841/test-process-env-with-jest
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // Most important - it clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  it('emits a message to the socket when a message is sent', async () => {
+    process.env.REACT_APP_TOWNS_SERVICE_URL = 'testurl.com';
     const dispatchAppUpdate = jest.fn();
     const initData = {
-        coveyUserID: "id",
-        coveySessionToken: "token",
-        providerVideoToken: "vid token",
-        currentPlayers: [],
-        friendlyName: "test town 123",
-        isPubliclyListed: true,
-    }  
-    
+      coveyUserID: 'id',
+      coveySessionToken: 'token',
+      providerVideoToken: 'vid token',
+      currentPlayers: [],
+      friendlyName: 'test town 123',
+      isPubliclyListed: true,
+    };
+
     await GameController(initData, dispatchAppUpdate);
-    
+
     const dispatchAppData = dispatchAppUpdate.mock.calls[0][0].data;
     const emitMessage = dispatchAppData.emitMessage;
-    console.log(emitMessage)
+    console.log(emitMessage);
     const socket = dispatchAppData.socket;
     const message = createMessageForTesting(MessageType.TownMessage, nanoid());
 
     emitMessage(message);
     expect(socket.emit).toBeCalledWith('messageSent', message);
+  });
 });

--- a/frontend/src/gameController.test.ts
+++ b/frontend/src/gameController.test.ts
@@ -1,0 +1,8 @@
+import { mock, mockReset,  } from 'jest-mock-extended';
+import { nanoid } from 'nanoid';
+import { Socket } from 'socket.io-client';
+import { GameController } from './GameController';
+
+describe('game controller', () => {
+    const mockSocket = mock<Socket>();
+})

--- a/frontend/src/gameController.test.ts
+++ b/frontend/src/gameController.test.ts
@@ -2,7 +2,7 @@ import { mock } from 'jest-mock-extended';
 import { nanoid } from 'nanoid';
 import { MessageType } from './classes/MessageChain';
 import Video from './classes/Video/Video';
-import { GameController } from './GameController';
+import GameController from './GameController';
 import { createMessageForTesting } from './TestUtils';
 
 jest.mock('./classes/Video/Video');
@@ -16,9 +16,7 @@ jest.mock('socket.io-client', () => ({
 
 const mockVideoSetup = mock<Video>();
 
-Video.instance = () => {
-  return mockVideoSetup;
-};
+Video.instance = () =>  mockVideoSetup;
 
 describe('game controller', () => {
   // from https://stackoverflow.com/questions/48033841/test-process-env-with-jest
@@ -47,10 +45,7 @@ describe('game controller', () => {
 
     await GameController(initData, dispatchAppUpdate);
 
-    const dispatchAppData = dispatchAppUpdate.mock.calls[0][0].data;
-    const emitMessage = dispatchAppData.emitMessage;
-    console.log(emitMessage);
-    const socket = dispatchAppData.socket;
+    const { emitMessage, socket } = dispatchAppUpdate.mock.calls[0][0].data;
     const message = createMessageForTesting(MessageType.TownMessage, nanoid());
 
     emitMessage(message);

--- a/frontend/src/gameController.test.ts
+++ b/frontend/src/gameController.test.ts
@@ -1,8 +1,46 @@
-import { mock, mockReset,  } from 'jest-mock-extended';
-import { nanoid } from 'nanoid';
-import { Socket } from 'socket.io-client';
-import { GameController } from './GameController';
+import * as socket from 'socket.io-client';
 
-describe('game controller', () => {
-    const mockSocket = mock<Socket>();
-})
+import { Socket } from 'socket.io-client';
+import { mock, mockReset } from 'jest-mock-extended';
+import { nanoid } from 'nanoid';
+import { GameController } from './GameController';
+import Video from './classes/Video/Video';
+import { createMessageForTesting } from './TestUtils';
+import { MessageType } from './classes/MessageChain';
+jest.mock('./classes/Video/Video');
+
+jest.mock('socket.io-client', () => ({
+    io: () => ({
+      on: jest.fn(),
+      emit: jest.fn(),
+    }),
+  }));
+
+  const mockVideoSetup = mock<Video>();
+    
+  Video.instance = () => {
+      return mockVideoSetup;
+  };
+
+it('emits a message to the socket when a message is sent', async () => {
+    const dispatchAppUpdate = jest.fn();
+    const initData = {
+        coveyUserID: "id",
+        coveySessionToken: "token",
+        providerVideoToken: "vid token",
+        currentPlayers: [],
+        friendlyName: "test town 123",
+        isPubliclyListed: true,
+    }  
+    
+    await GameController(initData, dispatchAppUpdate);
+    
+    const dispatchAppData = dispatchAppUpdate.mock.calls[0][0].data;
+    const emitMessage = dispatchAppData.emitMessage;
+    console.log(emitMessage)
+    const socket = dispatchAppData.socket;
+    const message = createMessageForTesting(MessageType.TownMessage, nanoid());
+
+    emitMessage(message);
+    expect(socket.emit).toBeCalledWith('messageSent', message);
+});

--- a/frontend/src/reducer.test.ts
+++ b/frontend/src/reducer.test.ts
@@ -25,6 +25,7 @@ const createSampleAppState = (): CoveyAppState => ({
     moving: false,
   },
   emitMovement: () => {},
+  emitMessage: () => {},
   apiClient: new TownsServiceClient(),
   townMessageChain: new MessageChain(),
   proximityMessageChain: new MessageChain(),

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -18,6 +18,7 @@ export type CoveyAppUpdate =
         socket: Socket;
         players: Player[];
         emitMovement: (location: UserLocation) => void;
+        emitMessage: (message: Message) => void;
       };
     }
   | { action: 'addPlayer'; player: Player }
@@ -45,6 +46,7 @@ export function defaultAppState(): CoveyAppState {
       moving: false,
     },
     emitMovement: () => {},
+    emitMessage: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),
@@ -64,6 +66,7 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
     userName: state.userName,
     socket: state.socket,
     emitMovement: state.emitMovement,
+    emitMessage: state.emitMessage,
     apiClient: state.apiClient,
     townMessageChain: state.townMessageChain,
     proximityMessageChain: state.proximityMessageChain,
@@ -103,6 +106,7 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
       nextState.currentTownIsPubliclyListed = update.data.townIsPubliclyListed;
       nextState.userName = update.data.userName;
       nextState.emitMovement = update.data.emitMovement;
+      nextState.emitMessage = update.data.emitMessage;
       nextState.socket = update.data.socket;
       nextState.players = update.data.players;
       break;


### PR DESCRIPTION
- Adds new `emitMessage` const in `GameController` that, when called, emits that a message was sent to the socket.
- Carries this through the app state, similar to how `emitMovement` works. This will allow this function to be called in components
- Splits the `GameController` function into its own file so that it can be tested
- Tests that `emitMessage` calls the socket properly

Note that a separate PR will handle the backend catching and using this socket event (basically bridging the gap between the socket event and `CoveyRownController.receiveMessage`)