### PR TITLE
feat: add callback to reset unviewed messages

### DIFF
--- a/frontend/src/CoveyTypes.ts
+++ b/frontend/src/CoveyTypes.ts
@@ -1,5 +1,5 @@
 import { Socket } from 'socket.io-client';
-import MessageChain, { Message, MessageChainHash } from './classes/MessageChain';
+import MessageChain, { Message, MessageChainHash, MessageType } from './classes/MessageChain';
 import Player, { UserLocation } from './classes/Player';
 import TownsServiceClient from './classes/TownsServiceClient';
 
@@ -31,6 +31,7 @@ export type CoveyAppState = {
   nearbyPlayers: NearbyPlayers;
   emitMovement: (location: UserLocation) => void;
   emitMessage: (message: Message) => void;
+  resetUnviewedMessages: (messageType: MessageType, directMessageId?: string) => void;
   socket: Socket | null;
   apiClient: TownsServiceClient;
   townMessageChain: MessageChain;

--- a/frontend/src/GameController.tsx
+++ b/frontend/src/GameController.tsx
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { io } from 'socket.io-client';
-import { Message } from './classes/MessageChain';
+import { Message, MessageType } from './classes/MessageChain';
 import Player, { ServerPlayer, UserLocation } from './classes/Player';
 import { TownJoinResponse } from './classes/TownsServiceClient';
 import Video from './classes/Video/Video';
@@ -50,6 +50,9 @@ export default async function GameController(
     // don't need to update the app with the sent message, the socket will emit messageReceived back to us
     // and we update it then
   };
+  const resetUnviewedMessages = (messageType: MessageType, directMessageId?: string):void => {
+    dispatchAppUpdate({ action: 'resetUnviewedMessages', messageType, directMessageId });
+  };
 
   dispatchAppUpdate({
     action: 'doConnect',
@@ -62,6 +65,7 @@ export default async function GameController(
       townIsPubliclyListed: video.isPubliclyListed,
       emitMovement,
       emitMessage,
+      resetUnviewedMessages,
       socket,
       players: initData.currentPlayers.map(sp => Player.fromServerPlayer(sp)),
     },

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -85,7 +85,8 @@ export default class MessageChain {
   /**
    * sets number of unviewed messages to zero
    */
-  resetNumberUnviewed(): void {
+  resetNumberUnviewed(): MessageChain {
     this._numberUnviewed = 0;
+    return this;
   }
 }

--- a/frontend/src/components/Login/TownSelectionPart1.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart1.test.tsx
@@ -104,6 +104,7 @@ function wrappedTownSelection() {
           },
           emitMovement: () => {},
           emitMessage: () => {},
+          resetUnviewedMessages: () => {},
           apiClient: new TownsServiceClient(),
           townMessageChain: new MessageChain(),
           proximityMessageChain: new MessageChain(),

--- a/frontend/src/components/Login/TownSelectionPart2.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart2.test.tsx
@@ -101,6 +101,7 @@ function wrappedTownSelection() {
     emitMovement: () => {
     },
     emitMessage: () => {},
+    resetUnviewedMessages: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),

--- a/frontend/src/components/Login/TownSelectionPart3.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart3.test.tsx
@@ -101,6 +101,7 @@ function wrappedTownSelection() {
     emitMovement: () => {
     },
     emitMessage: () => {},
+    resetUnviewedMessages: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),

--- a/frontend/src/components/Login/TownSettings.test.tsx
+++ b/frontend/src/components/Login/TownSettings.test.tsx
@@ -54,6 +54,7 @@ function wrappedTownSettings() {
     emitMovement: () => {
     },
     emitMessage: () => {},
+    resetUnviewedMessages: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),

--- a/frontend/src/gameController.test.ts
+++ b/frontend/src/gameController.test.ts
@@ -73,7 +73,7 @@ describe('game controller', () => {
     expect(socket.emit).toBeCalledWith('messageSent', message);
   });
 
-  it('dispatches an update to the socket when a unviewed messages are reset', async () => {
+  it('dispatches an update to the app when unviewed messages are reset', async () => {
     process.env.REACT_APP_TOWNS_SERVICE_URL = 'testurl.com';
     const dispatchAppUpdate = jest.fn();
     const initData = {

--- a/frontend/src/gameController.test.ts
+++ b/frontend/src/gameController.test.ts
@@ -16,7 +16,7 @@ jest.mock('socket.io-client', () => ({
 
 const mockVideoSetup = mock<Video>();
 
-Video.instance = () =>  mockVideoSetup;
+Video.instance = () => mockVideoSetup;
 
 describe('game controller', () => {
   // from https://stackoverflow.com/questions/48033841/test-process-env-with-jest
@@ -31,6 +31,27 @@ describe('game controller', () => {
     process.env = OLD_ENV; // Restore old environment
   });
 
+  it('creates a listener for message received socket events', async () => {
+    process.env.REACT_APP_TOWNS_SERVICE_URL = 'testurl.com';
+    const dispatchAppUpdate = jest.fn();
+    const initData = {
+      coveyUserID: 'id',
+      coveySessionToken: 'token',
+      providerVideoToken: 'vid token',
+      currentPlayers: [],
+      friendlyName: 'test town 123',
+      isPubliclyListed: true,
+    };
+
+    await GameController(initData, dispatchAppUpdate);
+
+    const { socket } = dispatchAppUpdate.mock.calls[0][0].data;
+    const message = createMessageForTesting(MessageType.TownMessage, nanoid());
+
+    const messageReceived = socket.on.mock.calls[4][1];
+    messageReceived(message);
+    expect(dispatchAppUpdate).toHaveBeenCalledWith({ action: 'messageReceived', message });
+  });
   it('emits a message to the socket when a message is sent', async () => {
     process.env.REACT_APP_TOWNS_SERVICE_URL = 'testurl.com';
     const dispatchAppUpdate = jest.fn();
@@ -50,5 +71,29 @@ describe('game controller', () => {
 
     emitMessage(message);
     expect(socket.emit).toBeCalledWith('messageSent', message);
+  });
+
+  it('dispatches an update to the socket when a unviewed messages are reset', async () => {
+    process.env.REACT_APP_TOWNS_SERVICE_URL = 'testurl.com';
+    const dispatchAppUpdate = jest.fn();
+    const initData = {
+      coveyUserID: 'id',
+      coveySessionToken: 'token',
+      providerVideoToken: 'vid token',
+      currentPlayers: [],
+      friendlyName: 'test town 123',
+      isPubliclyListed: true,
+    };
+
+    await GameController(initData, dispatchAppUpdate);
+
+    const { resetUnviewedMessages } = dispatchAppUpdate.mock.calls[0][0].data;
+
+    resetUnviewedMessages(MessageType.DirectMessage, '123:234');
+    expect(dispatchAppUpdate).toBeCalledWith({
+      action: 'resetUnviewedMessages',
+      messageType: MessageType.DirectMessage,
+      directMessageId: '123:234',
+    });
   });
 });

--- a/frontend/src/reducer.test.ts
+++ b/frontend/src/reducer.test.ts
@@ -26,6 +26,7 @@ const createSampleAppState = (): CoveyAppState => ({
   },
   emitMovement: () => {},
   emitMessage: () => {},
+  resetUnviewedMessages: () => {},
   apiClient: new TownsServiceClient(),
   townMessageChain: new MessageChain(),
   proximityMessageChain: new MessageChain(),
@@ -123,7 +124,7 @@ describe('reducer', () => {
         player1Id,
         player2Id,
       );
-      
+
       const firstState = appStateReducer(createSampleAppState(), {
         action: 'messageReceived',
         message: messageToTest,
@@ -169,6 +170,124 @@ describe('reducer', () => {
       });
 
       expect(secondState.directMessageChains[directMessageId].isActive).toBe(false);
+    });
+  });
+  describe('resetUnviewedMessages', () => {
+    it('resets the unviewed messages for a town message chain', () => {
+      const messageToTest = createMessageForTesting(MessageType.TownMessage, nanoid());
+      const message2ToTest = createMessageForTesting(MessageType.ProximityMessage, nanoid());
+      const message3ToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+
+      let state = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      state = appStateReducer(state, {
+        action: 'messageReceived',
+        message: message2ToTest,
+      });
+      state = appStateReducer(state, {
+        action: 'messageReceived',
+        message: message3ToTest,
+      });
+
+      expect(state.townMessageChain.numberUnviewed).toBe(1);
+      expect(state.proximityMessageChain.numberUnviewed).toBe(1);
+      expect(state.directMessageChains[directMessageId].numberUnviewed).toBe(1);
+
+      state = appStateReducer(state, {
+        action: 'resetUnviewedMessages',
+        messageType: MessageType.TownMessage,
+      });
+      expect(state.townMessageChain.numberUnviewed).toBe(0);
+      expect(state.proximityMessageChain.numberUnviewed).toBe(1);
+      expect(state.directMessageChains[directMessageId].numberUnviewed).toBe(1);
+    });
+    it('resets the unviewed messages for a proximity message chain', () => {
+      const messageToTest = createMessageForTesting(MessageType.TownMessage, nanoid());
+      const message2ToTest = createMessageForTesting(MessageType.ProximityMessage, nanoid());
+      const message3ToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+
+      let state = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      state = appStateReducer(state, {
+        action: 'messageReceived',
+        message: message2ToTest,
+      });
+      state = appStateReducer(state, {
+        action: 'messageReceived',
+        message: message3ToTest,
+      });
+
+      expect(state.townMessageChain.numberUnviewed).toBe(1);
+      expect(state.proximityMessageChain.numberUnviewed).toBe(1);
+      expect(state.directMessageChains[directMessageId].numberUnviewed).toBe(1);
+
+      state = appStateReducer(state, {
+        action: 'resetUnviewedMessages',
+        messageType: MessageType.ProximityMessage,
+      });
+      expect(state.townMessageChain.numberUnviewed).toBe(1);
+      expect(state.proximityMessageChain.numberUnviewed).toBe(0);
+      expect(state.directMessageChains[directMessageId].numberUnviewed).toBe(1);
+    });
+
+    it('resets the unviewed messages for a direct message chain', () => {
+      const messageToTest = createMessageForTesting(MessageType.TownMessage, nanoid());
+      const message2ToTest = createMessageForTesting(MessageType.ProximityMessage, nanoid());
+      const message3ToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+      );
+      const message4ToTest = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        '4321',
+      );
+
+
+      let state = appStateReducer(createSampleAppState(), {
+        action: 'messageReceived',
+        message: messageToTest,
+      });
+      state = appStateReducer(state, {
+        action: 'messageReceived',
+        message: message2ToTest,
+      });
+      state = appStateReducer(state, {
+        action: 'messageReceived',
+        message: message3ToTest,
+      });
+      state = appStateReducer(state, {
+        action: 'messageReceived',
+        message: message4ToTest,
+      });
+
+
+      expect(state.townMessageChain.numberUnviewed).toBe(1);
+      expect(state.proximityMessageChain.numberUnviewed).toBe(1);
+      expect(state.directMessageChains[directMessageId].numberUnviewed).toBe(1);
+
+      state = appStateReducer(state, {
+        action: 'resetUnviewedMessages',
+        messageType: MessageType.DirectMessage,
+        directMessageId,
+      });
+      expect(state.townMessageChain.numberUnviewed).toBe(1);
+      expect(state.proximityMessageChain.numberUnviewed).toBe(1);
+      expect(state.directMessageChains[directMessageId].numberUnviewed).toBe(0);
+      expect(state.directMessageChains['123:4321'].numberUnviewed).toBe(1);
     });
   });
 });

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -19,6 +19,7 @@ export type CoveyAppUpdate =
         players: Player[];
         emitMovement: (location: UserLocation) => void;
         emitMessage: (message: Message) => void;
+        resetUnviewedMessages: (messageType: MessageType, directMessageId?: string) => void;
       };
     }
   | { action: 'addPlayer'; player: Player }
@@ -26,7 +27,8 @@ export type CoveyAppUpdate =
   | { action: 'playerDisconnect'; player: Player }
   | { action: 'weMoved'; location: UserLocation }
   | { action: 'disconnect' }
-  | { action: 'messageReceived'; message: Message };
+  | { action: 'messageReceived'; message: Message }
+  | { action: 'resetUnviewedMessages'; messageType: MessageType; directMessageId?: string };
 
 export function defaultAppState(): CoveyAppState {
   return {
@@ -47,6 +49,7 @@ export function defaultAppState(): CoveyAppState {
     },
     emitMovement: () => {},
     emitMessage: () => {},
+    resetUnviewedMessages: () => {},
     apiClient: new TownsServiceClient(),
     townMessageChain: new MessageChain(),
     proximityMessageChain: new MessageChain(),
@@ -67,6 +70,7 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
     socket: state.socket,
     emitMovement: state.emitMovement,
     emitMessage: state.emitMessage,
+    resetUnviewedMessages: state.resetUnviewedMessages,
     apiClient: state.apiClient,
     townMessageChain: state.townMessageChain,
     proximityMessageChain: state.proximityMessageChain,
@@ -107,7 +111,7 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
       nextState.userName = update.data.userName;
       nextState.emitMovement = update.data.emitMovement;
       nextState.emitMessage = update.data.emitMessage;
-      nextState.socket = update.data.socket;
+      nextState.resetUnviewedMessages, (nextState.socket = update.data.socket);
       nextState.players = update.data.players;
       break;
     case 'addPlayer':
@@ -183,6 +187,20 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
               : new MessageChain(update.message);
           }
           break;
+      }
+      break;
+    case 'resetUnviewedMessages':
+      if (update.messageType === MessageType.TownMessage) {
+        nextState.townMessageChain = nextState.townMessageChain.resetNumberUnviewed();
+      } else if (update.messageType === MessageType.ProximityMessage) {
+        nextState.proximityMessageChain = nextState.proximityMessageChain.resetNumberUnviewed();
+      } else if (update.directMessageId) {
+        directMessageChainToUpdate = nextState.directMessageChains[update.directMessageId];
+        if (directMessageChainToUpdate) {
+          nextState.directMessageChains[
+            update.directMessageId
+          ] = directMessageChainToUpdate.resetNumberUnviewed();
+        }
       }
       break;
     default:

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -111,7 +111,7 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
       nextState.userName = update.data.userName;
       nextState.emitMovement = update.data.emitMovement;
       nextState.emitMessage = update.data.emitMessage;
-      nextState.resetUnviewedMessages, (nextState.socket = update.data.socket);
+      nextState.socket = update.data.socket;
       nextState.players = update.data.players;
       break;
     case 'addPlayer':


### PR DESCRIPTION
adds a `resetUnviewedMessages` callback that allows react components to set the unviewed messages count to zero whenever the new messages are viewed. 