### PR TITLE
feat: Add functionality to the backend to receive an emission

### DIFF
--- a/frontend/src/TestUtils.ts
+++ b/frontend/src/TestUtils.ts
@@ -7,7 +7,7 @@ export function createMessageForTesting(
   player2Id?: string,
 ): Message {
   const timestamp = Date.now();
-  let directMessageID;
+  let directMessageID = null;
   if (player2Id) {
     directMessageID = `${player1Id}:${player2Id}`;
   }

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -14,7 +14,7 @@ export type Message = {
   timestamp: number;
   type: MessageType;
   // null for cases of Proximity and Town Message
-  directMessageId: string | undefined;
+  directMessageId: string | null;
 };
 
 export interface MessageChainHash {

--- a/frontend/src/components/Chat/ChatContainer.tsx
+++ b/frontend/src/components/Chat/ChatContainer.tsx
@@ -17,7 +17,7 @@ const sampleMessage: Message = {
     rotation: 'front',
     moving: false,
   },
-  directMessageId: undefined,
+  directMessageId: null,
 };
 
 export default function ChatContainer(): JSX.Element {

--- a/frontend/src/components/Chat/SingleMessage.test.tsx
+++ b/frontend/src/components/Chat/SingleMessage.test.tsx
@@ -17,7 +17,7 @@ const sampleMessage: Message = {
     rotation: 'front',
     moving: false,
   },
-  directMessageId: undefined,
+  directMessageId: null,
 };
 
 describe('SingleMessage', () => {

--- a/services/roomService/src/CoveyTypes.ts
+++ b/services/roomService/src/CoveyTypes.ts
@@ -22,5 +22,5 @@ export type Message = {
   timestamp: number;
   type: MessageType;
   // null for cases of Proximity and Town Message
-  directMessageId: string | undefined;
+  directMessageId: string | null;
 };

--- a/services/roomService/src/client/CoveyTownsSocket.test.ts
+++ b/services/roomService/src/client/CoveyTownsSocket.test.ts
@@ -87,12 +87,8 @@ describe('TownServiceApiSocket', () => {
     const {messageReceived} = TestUtils.createSocketClient(server, joinData2.coveySessionToken, town.coveyTownID);
     const {messageReceived: messageReceived2} = TestUtils.createSocketClient(server, joinData3.coveySessionToken, town.coveyTownID);
     const message = TestUtils.createMessageForTesting(MessageType.TownMessage, new Player(nanoid()));
-    console.log('created message');
-    console.log(message)
     socketSender.emit('messageSent', message);
     const [receivedMessage, otherReceivedMessage]= await Promise.all([messageReceived, messageReceived2]);
-    console.log('message after being sent through socket')
-    console.log(receivedMessage);
     expect(receivedMessage).toMatchObject(message);
     expect(otherReceivedMessage).toMatchObject(message);
   });

--- a/services/roomService/src/client/CoveyTownsSocket.test.ts
+++ b/services/roomService/src/client/CoveyTownsSocket.test.ts
@@ -98,7 +98,7 @@ describe('TownServiceApiSocket', () => {
     const joinData = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});
     const joinData2 = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});
     const joinData3 = await apiClient.joinTown({coveyTownID: town.coveyTownID, userName: nanoid()});
-    const {socket: movementSocket, messageReceived: shouldNotResolve} = TestUtils.createSocketClient(server, joinData.coveySessionToken, town.coveyTownID);
+    const {socket: movementSocket} = TestUtils.createSocketClient(server, joinData.coveySessionToken, town.coveyTownID);
     const {socket: messageSocket, messageReceived, playerMoved} = TestUtils.createSocketClient(server, joinData2.coveySessionToken, town.coveyTownID);
     const {messageReceived: messageReceived2, playerMoved: playerMoved2} = TestUtils.createSocketClient(server, joinData3.coveySessionToken, town.coveyTownID);
 
@@ -112,11 +112,8 @@ describe('TownServiceApiSocket', () => {
     const [firstMessage, secondMessage] = await Promise.all([messageReceived, messageReceived2]); // It should therefore be received by these two clients
     expect(firstMessage).toMatchObject(message);
     expect(secondMessage).toMatchObject(message);
-    try {
-      await shouldNotResolve; // but not the first one, which is out of range
-    } catch (e) {
-      expect(e).toBeTruthy
-    }
+    // sadly no way of checking that the first client will NOT receive the message. However, if you modify this test to try 
+    // and await a messageReceived promise from it, the test will timeout.
   });
   it('Invalidates the user session after disconnection', async () => {
     // This test will timeout if it fails - it will never reach the expectation

--- a/services/roomService/src/client/TestUtils.ts
+++ b/services/roomService/src/client/TestUtils.ts
@@ -50,6 +50,7 @@ export function createSocketClient(
     socketConnected: Promise<void>;
     socketDisconnected: Promise<void>;
     playerMoved: Promise<RemoteServerPlayer>;
+    messageReceived: Promise<Message>;
     newPlayerJoined: Promise<RemoteServerPlayer>;
     playerDisconnected: Promise<RemoteServerPlayer>;
   }  {
@@ -74,6 +75,11 @@ export function createSocketClient(
       resolve(player);
     });
   });
+  const messageReceivedPromise = new Promise<Message>(resolve => {
+    socket.on('messageReceived', (message: Message) => {
+      resolve(message);
+    });
+  });
   const newPlayerPromise = new Promise<RemoteServerPlayer>(resolve => {
     socket.on('newPlayer', (player: RemoteServerPlayer) => {
       resolve(player);
@@ -90,6 +96,7 @@ export function createSocketClient(
     socketConnected: connectPromise,
     socketDisconnected: disconnectPromise,
     playerMoved: playerMovedPromise,
+    messageReceived: messageReceivedPromise,
     newPlayerJoined: newPlayerPromise,
     playerDisconnected: playerDisconnectPromise,
   };
@@ -113,7 +120,7 @@ export function createMessageForTesting(type: MessageType, player1: Player): Mes
       messageContent: "Omg I'm a test",
       timestamp,
       type,
-      directMessageId: undefined,
+      directMessageId: null,
     };
   }
   return {
@@ -123,6 +130,6 @@ export function createMessageForTesting(type: MessageType, player1: Player): Mes
     messageContent: "Omg I'm a test",
     timestamp,
     type,
-    directMessageId: undefined,
+    directMessageId: null,
   };
 }

--- a/services/roomService/src/lib/CoveyTownController.test.ts
+++ b/services/roomService/src/lib/CoveyTownController.test.ts
@@ -352,7 +352,7 @@ describe('CoveyTownController', () => {
           fail('No playerMovement handler registered');
         }
       });
-      it('should forward messageSent events from the socket to subscribed listeners', async() => {
+      it('should forward messageSent events from the socket to subscribed listeners', async () => {
         TestUtils.setSessionTokenAndTownID(
           testingTown.coveyTownID,
           session.sessionToken,

--- a/services/roomService/src/lib/CoveyTownController.test.ts
+++ b/services/roomService/src/lib/CoveyTownController.test.ts
@@ -253,6 +253,17 @@ describe('CoveyTownController', () => {
         testingTown.updatePlayerLocation(player, generateTestLocation());
         expect(mockSocket.emit).toBeCalledWith('playerMoved', player);
       });
+      it('should add a town listener, which should emit "messageReceived" to the socket when a message is received', async () => {
+        TestUtils.setSessionTokenAndTownID(
+          testingTown.coveyTownID,
+          session.sessionToken,
+          mockSocket,
+        );
+        townSubscriptionHandler(mockSocket);
+        const message = TestUtils.createMessageForTesting(MessageType.TownMessage, new Player(nanoid()));
+        testingTown.receiveMessage(message);
+        expect(mockSocket.emit).toBeCalledWith('messageReceived', message);
+      });
       it('should add a town listener, which should emit "playerDisconnect" to the socket when a player disconnects', async () => {
         TestUtils.setSessionTokenAndTownID(
           testingTown.coveyTownID,
@@ -339,6 +350,27 @@ describe('CoveyTownController', () => {
           expect(mockListener.onPlayerMoved).toHaveBeenCalledWith(player);
         } else {
           fail('No playerMovement handler registered');
+        }
+      });
+      it('should forward messageSent events from the socket to subscribed listeners', async() => {
+        TestUtils.setSessionTokenAndTownID(
+          testingTown.coveyTownID,
+          session.sessionToken,
+          mockSocket,
+        );
+        townSubscriptionHandler(mockSocket);
+        const mockListener = mock<CoveyTownListener>();
+        testingTown.addTownListener(mockListener);
+        // find the 'messageSent' event handler for the socket, which should have been registered after the socket was connected
+        const messageSentHandler = mockSocket.on.mock.calls.find(
+          call => call[0] === 'messageSent',
+        );
+        if (messageSentHandler && messageSentHandler[1]) {
+          const testMessage = TestUtils.createMessageForTesting(MessageType.TownMessage, new Player(nanoid()));
+          messageSentHandler[1](testMessage);
+          expect(mockListener.onMessageReceived).toHaveBeenCalledWith(testMessage);
+        } else {
+          fail('No messageSent handler registered');
         }
       });
     });

--- a/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
+++ b/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
@@ -253,4 +253,10 @@ export function townSubscriptionHandler(socket: Socket): void {
   socket.on('playerMovement', (movementData: UserLocation) => {
     townController.updatePlayerLocation(s.player, movementData);
   });
+
+  // Register an event listener for the client socket: if the client sends 
+  // a message, inform the CoveyTownController
+  socket.on('messageSent', (message: Message) => {
+    townController.receiveMessage(message);
+  });
 }


### PR DESCRIPTION
- Adds functionality in the backend to receive a socket emission from the frontend when a player sends a message. This is the last step in the socket architecture, so message sending/receiving should be good to go when this is merged in!
- Adds tests. Note that proximity chat and DMs can't be tested at the `CoveyTownsSocket.test` level, as this would require checking that a Promise doesn't resolve. Therefore we're taking the Controller tests as "good enough" since they test the part in the code that actually handles the DM/Proximity logic.
- Changes the `directMessageId` from `undefined` to `null` on Messages that aren't DMs. This is because the socket will serialize the `Message` object to JSON when it is emitted, and `undefined` is an unsupported type in JSON.