### PR TITLE
fix: Change participants list to be an array of { userName, userId }

### DIFF
--- a/frontend/src/TestUtils.ts
+++ b/frontend/src/TestUtils.ts
@@ -8,11 +8,14 @@ export function createMessageForTesting(
 ): Message {
   const timestamp = Date.now();
   let directMessageID = null;
+  let toUserName = null;
   if (player2Id) {
     directMessageID = `${player1Id}:${player2Id}`;
+    toUserName = nanoid();
   }
   return {
-    userName: nanoid(),
+    fromUserName: nanoid(),
+    toUserName: toUserName,
     userId: player1Id,
     location: { x: 1, y: 2, rotation: 'front', moving: false },
     messageContent: "Omg I'm a test",

--- a/frontend/src/TestUtils.ts
+++ b/frontend/src/TestUtils.ts
@@ -15,7 +15,7 @@ export function createMessageForTesting(
   }
   return {
     fromUserName: nanoid(),
-    toUserName: toUserName,
+    toUserName,
     userId: player1Id,
     location: { x: 1, y: 2, rotation: 'front', moving: false },
     messageContent: "Omg I'm a test",

--- a/frontend/src/TestUtils.ts
+++ b/frontend/src/TestUtils.ts
@@ -5,8 +5,8 @@ export function createMessageForTesting(
   type: MessageType,
   player1Id: string,
   player2Id?: string,
+  timestamp?: number,
 ): Message {
-  const timestamp = Date.now();
   let directMessageID = null;
   let toUserName = null;
   if (player2Id) {
@@ -19,7 +19,7 @@ export function createMessageForTesting(
     userId: player1Id,
     location: { x: 1, y: 2, rotation: 'front', moving: false },
     messageContent: "Omg I'm a test",
-    timestamp,
+    timestamp: timestamp || Date.now(),
     type,
     directMessageId: directMessageID,
   };

--- a/frontend/src/classes/MessageChain.test.ts
+++ b/frontend/src/classes/MessageChain.test.ts
@@ -77,5 +77,26 @@ describe('MessageChain', () => {
       testChain.addMessage(secondMessage);
       expect(testChain.messages.length).toBe(1);
     });
+    it('should not allow for duplicate message to be added to MessageChain', () => {
+      const player1Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      testChain.addMessage(secondMessage);
+      expect(testChain.messages.length).toBe(2);
+      expect(secondMessage).toBe(testChain.messages[1]);
+      testChain.addMessage(firstMessage);
+      expect(testChain.messages.length).toBe(2);
+      expect(secondMessage).toBe(testChain.messages[1]);
+    });
+    it('should not allow for duplicate message to be added to MessageChain', () => {
+      const player1Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      testChain.addMessage(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+    });
   });
 });

--- a/frontend/src/classes/MessageChain.test.ts
+++ b/frontend/src/classes/MessageChain.test.ts
@@ -46,8 +46,14 @@ describe('MessageChain', () => {
       const player1Id = nanoid();
       const player2Id = nanoid();
       const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1Id, player2Id);
+      firstMessage.fromUserName = 'testFromUser'
+      firstMessage.toUserName = 'testToUser'
       const testChain = createMessageChainForTesting(firstMessage);
       expect(testChain.participants?.length).toBe(2);
+      expect(testChain.participants).toEqual(expect.arrayContaining([
+        expect.objectContaining({ userName: firstMessage.fromUserName, userId: player1Id }),
+        expect.objectContaining({ userName: firstMessage.toUserName, userId: player2Id }),
+      ]))
     });
   });
   describe('addMessage', () => {

--- a/frontend/src/classes/MessageChain.test.ts
+++ b/frontend/src/classes/MessageChain.test.ts
@@ -46,14 +46,16 @@ describe('MessageChain', () => {
       const player1Id = nanoid();
       const player2Id = nanoid();
       const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1Id, player2Id);
-      firstMessage.fromUserName = 'testFromUser'
-      firstMessage.toUserName = 'testToUser'
+      firstMessage.fromUserName = 'testFromUser';
+      firstMessage.toUserName = 'testToUser';
       const testChain = createMessageChainForTesting(firstMessage);
       expect(testChain.participants?.length).toBe(2);
-      expect(testChain.participants).toEqual(expect.arrayContaining([
-        expect.objectContaining({ userName: firstMessage.fromUserName, userId: player1Id }),
-        expect.objectContaining({ userName: firstMessage.toUserName, userId: player2Id }),
-      ]))
+      expect(testChain.participants).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ userName: firstMessage.fromUserName, userId: player1Id }),
+          expect.objectContaining({ userName: firstMessage.toUserName, userId: player2Id }),
+        ]),
+      );
     });
   });
   describe('addMessage', () => {
@@ -77,18 +79,26 @@ describe('MessageChain', () => {
       testChain.addMessage(secondMessage);
       expect(testChain.messages.length).toBe(1);
     });
-    it('should not allow for duplicate message to be added to MessageChain', () => {
+    it('should allow for messages sent at same time to be added to MessageChain if each from different player', () => {
       const player1Id = nanoid();
-      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const player2Id = nanoid();
+      const timestamp = Date.now();
+      const firstMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+        timestamp,
+      );
       const testChain = createMessageChainForTesting(firstMessage);
       expect(testChain.messages.length).toBe(1);
-      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const secondMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player2Id,
+        player1Id,
+        timestamp,
+      );
       testChain.addMessage(secondMessage);
       expect(testChain.messages.length).toBe(2);
-      expect(secondMessage).toBe(testChain.messages[1]);
-      testChain.addMessage(firstMessage);
-      expect(testChain.messages.length).toBe(2);
-      expect(secondMessage).toBe(testChain.messages[1]);
     });
     it('should not allow for duplicate message to be added to MessageChain', () => {
       const player1Id = nanoid();
@@ -97,6 +107,30 @@ describe('MessageChain', () => {
       expect(testChain.messages.length).toBe(1);
       testChain.addMessage(firstMessage);
       expect(testChain.messages.length).toBe(1);
+    });
+
+    it('should not check for duplicates past older timestamps', () => {
+      const player1Id = nanoid();
+      const player2Id = nanoid();
+      const timestamp = Date.now();
+      const timestampOlder = Date.now() - 1;
+      const firstMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+        timestamp,
+      );
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      const secondMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player2Id,
+        player1Id,
+        timestampOlder,
+      );
+      testChain.addMessage(secondMessage);
+      testChain.addMessage(firstMessage);
+      expect(testChain.messages.length).toBe(3);
     });
   });
 });

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -106,7 +106,7 @@ export default class MessageChain {
   }
 
   isDuplicateMessage(newMessage: Message): boolean {
-    for (let i = this._messages.length - 1; i >= 0; i = i - 1) {
+    for (let i = this._messages.length - 1; i >= 0; i -= 1) {
       const messageToCheck = this._messages[i];
       if (messageToCheck.timestamp < newMessage.timestamp) {
         return false;

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -106,7 +106,7 @@ export default class MessageChain {
   }
 
   isDuplicateMessage(newMessage: Message): boolean {
-    for (let i = this._messages.length - 1; i >= 0; i--) {
+    for (let i = this._messages.length - 1; i >= 0; i = i - 1) {
       const messageToCheck = this._messages[i];
       if (messageToCheck.timestamp < newMessage.timestamp) {
         return false;

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -12,7 +12,7 @@ function createParticipants(
   fromUserName: string,
   toUserName: string,
 ): DirectMessageParticipant[] {
-  const participantIds = directMessageId.split(':')
+  const participantIds = directMessageId.split(':');
   const toId = participantIds.filter(id => id !== fromId)[0];
   const fromParticipant = { userName: fromUserName, userId: fromId };
   const toParticipant = { userName: toUserName, userId: toId };
@@ -56,7 +56,12 @@ export default class MessageChain {
     this._isActive = true;
     if (message && message.directMessageId && message.toUserName) {
       this._directMessageId = message.directMessageId;
-      this._participants = createParticipants(message.directMessageId, message.userId, message.fromUserName, message.toUserName);
+      this._participants = createParticipants(
+        message.directMessageId,
+        message.userId,
+        message.fromUserName,
+        message.toUserName,
+      );
       this._messages.push(message);
       this._numberUnviewed = 1;
     } else {
@@ -92,13 +97,28 @@ export default class MessageChain {
    * Adds new message to this message chain.
    * @param newMessage The new message to add to this chain
    */
-  addMessage(newMessage: Message): MessageChain {
-    if (this._isActive) {
+  addMessage(newMessage: Message):MessageChain {
+    if (this._isActive && !this.isDuplicateMessage(newMessage)) {
       this._messages.push(newMessage);
       this._numberUnviewed += 1;
     }
-
     return this;
+  }
+
+  isDuplicateMessage(newMessage: Message): boolean {
+    for (let i = this._messages.length - 1; i >= 0; i--) {
+      const messageToCheck = this._messages[i];
+      if (messageToCheck.timestamp < newMessage.timestamp) {
+        return false;
+      }
+      if (
+        newMessage.timestamp === messageToCheck.timestamp &&
+        messageToCheck.fromUserName === newMessage.fromUserName
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -6,6 +6,19 @@ export enum MessageType {
   TownMessage = 'TownMessage',
 }
 
+function createParticipants(
+  directMessageId: string,
+  fromId: string,
+  fromUserName: string,
+  toUserName: string,
+): DirectMessageParticipant[] {
+  const participantIds = directMessageId.split(':')
+  const toId = participantIds.filter(id => id !== fromId)[0];
+  const fromParticipant = { userName: fromUserName, userId: fromId };
+  const toParticipant = { userName: toUserName, userId: toId };
+  return [fromParticipant, toParticipant];
+}
+
 export type Message = {
   userId: string;
   fromUserName: string; // matches the user Id
@@ -43,7 +56,7 @@ export default class MessageChain {
     this._isActive = true;
     if (message && message.directMessageId && message.toUserName) {
       this._directMessageId = message.directMessageId;
-      this._participants = this.createParticipants(message.directMessageId, message.userId, message.fromUserName, message.toUserName);
+      this._participants = createParticipants(message.directMessageId, message.userId, message.fromUserName, message.toUserName);
       this._messages.push(message);
       this._numberUnviewed = 1;
     } else {
@@ -94,18 +107,5 @@ export default class MessageChain {
   resetNumberUnviewed(): MessageChain {
     this._numberUnviewed = 0;
     return this;
-  }
-
-  private createParticipants(
-    directMessageId: string,
-    fromId: string,
-    fromUserName: string,
-    toUserName: string,
-  ): DirectMessageParticipant[] {
-    const participantIds = directMessageId.split(':')
-    const toId = participantIds.filter(id => id !== fromId)[0];
-    const fromParticipant = { userName: fromUserName, userId: fromId };
-    const toParticipant = { userName: toUserName, userId: toId };
-    return [fromParticipant, toParticipant];
   }
 }

--- a/frontend/src/components/Chat/ChatContainer.tsx
+++ b/frontend/src/components/Chat/ChatContainer.tsx
@@ -6,7 +6,8 @@ import SingleMessage from './SingleMessage';
 
 // delete when real messages exist
 const sampleMessage: Message = {
-  userName: 'sampleName',
+  fromUserName: 'sampleName',
+  toUserName: null,
   userId: '33333',
   timestamp: Date.now(),
   messageContent:

--- a/frontend/src/components/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/Chat/ChatInput.test.tsx
@@ -31,13 +31,13 @@ function wrappedChatInput(isDisabled = false) {
       <CoveyAppContext.Provider
         value={{
           nearbyPlayers: { nearbyPlayers: [] },
-          players: [new Player('123', 'test', sampleLocation)],
+          players: [new Player('123', 'test from', sampleLocation), new Player('321', 'test to', sampleLocation)],
           myPlayerID: '123',
           currentTownID: '',
           currentTownIsPubliclyListed: false,
           currentTownFriendlyName: '',
           sessionToken: '',
-          userName: 'mockName',
+          userName: 'test from',
           socket: null,
           currentLocation: sampleLocation,
           emitMovement: () => {},
@@ -108,7 +108,8 @@ describe('ChatInput', () => {
     fireEvent.submit(renderData.getByTestId('chat-form'));
     expect(mockEmitMessage).toHaveBeenCalledWith({
       userId: '123',
-      userName: 'mockName',
+      fromUserName: 'test from',
+      toUserName: 'test to',
       timestamp: expect.any(Number),
       location: sampleLocation,
       messageContent: 'new value',
@@ -129,7 +130,8 @@ describe('ChatInput', () => {
     });
     expect(mockEmitMessage).toHaveBeenCalledWith({
       userId: '123',
-      userName: 'mockName',
+      fromUserName: 'test from',
+      toUserName: 'test to',
       timestamp: expect.any(Number),
       location: sampleLocation,
       messageContent: 'new value',

--- a/frontend/src/components/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/Chat/ChatInput.test.tsx
@@ -148,7 +148,8 @@ describe('ChatInput', () => {
         target: { value: 'new value' },
       });
       fireEvent.submit(renderData.getByTestId('chat-form'));
-      expect(mockPlayerArray.find).not.toHaveBeenCalled();
+      // confirms that the "shortcut" of using the participants list is being used, not CoveyAppState.players
+      expect(mockPlayerArray.find).not.toHaveBeenCalled(); 
       expect(mockEmitMessage).toHaveBeenCalledWith({
         userId: '123',
         fromUserName: 'test from',

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -15,19 +15,32 @@ interface ChatInputProps {
 // an input for sending messages from frontend to the socket
 function ChatInput({ messageType, directMessageId, isDisabled }: ChatInputProps): JSX.Element {
   const [messageContent, setMessageContent] = useState<string>('');
-  const { myPlayerID, emitMessage, currentLocation, userName, players } = useCoveyAppState();
+  const {
+    myPlayerID,
+    emitMessage,
+    currentLocation,
+    userName,
+    players,
+    directMessageChains,
+  } = useCoveyAppState();
   const video = useMaybeVideo();
   const canSendMessage = messageContent && messageContent.length;
 
   let toUserName: string | null = null;
   if (directMessageId) {
-    const participantIds = directMessageId.split(':')
-    const toId = participantIds.filter(id => id !== myPlayerID)[0];
-    const toPlayer: Player | undefined = players.find(
-      (playerToCheck: Player) => playerToCheck.id === toId,
-    );
-    if (toPlayer) {
-      toUserName = toPlayer.userName;
+    const directMessageChain = directMessageChains[directMessageId]
+    if (directMessageChain && directMessageChain.participants) {
+      const toParticipant = directMessageChain.participants.filter(participant => participant.userId !== myPlayerID)[0];
+      toUserName = toParticipant.userName;
+    } else {
+      const participantIds = directMessageId.split(':');
+      const toId = participantIds.filter(id => id !== myPlayerID)[0];
+      const toPlayer: Player | undefined = players.find(
+        (playerToCheck: Player) => playerToCheck.id === toId,
+      );
+      if (toPlayer) {
+        toUserName = toPlayer.userName;
+      }
     }
   }
 

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -54,6 +54,7 @@ function ChatInput({ messageType, directMessageId, isDisabled }: ChatInputProps)
     [
       canSendMessage,
       myPlayerID,
+      toUserName,
       directMessageId,
       messageType,
       emitMessage,

--- a/frontend/src/components/Chat/SingleMessage.test.tsx
+++ b/frontend/src/components/Chat/SingleMessage.test.tsx
@@ -5,7 +5,8 @@ import { Message, MessageType } from '../../classes/MessageChain';
 import SingleMessage from './SingleMessage';
 
 const sampleMessage: Message = {
-  userName: 'sampleName',
+  fromUserName: 'sampleName',
+  toUserName: null,
   userId: '123456',
   timestamp: 1616797320000,
   messageContent:
@@ -24,7 +25,7 @@ describe('SingleMessage', () => {
   it('renders message when message is sent by the player', () => {
     const renderData = render(<SingleMessage message={sampleMessage} myPlayerID='123456' />);
     renderData.getByTestId('sent-from-us');
-    renderData.getByText(`${sampleMessage.userName}#3456`);
+    renderData.getByText(`${sampleMessage.fromUserName}#3456`);
     renderData.getByText(moment(sampleMessage.timestamp).calendar());
     renderData.getByTestId('first-spacer');
     renderData.getByText(sampleMessage.messageContent);
@@ -35,7 +36,7 @@ describe('SingleMessage', () => {
   it('renders message when message is sent by a different player', () => {
     const renderData = render(<SingleMessage message={sampleMessage} myPlayerID='453621' />);
     renderData.getByTestId('sent-from-them');
-    renderData.getByText(`${sampleMessage.userName}#3456`);
+    renderData.getByText(`${sampleMessage.fromUserName}#3456`);
     renderData.getByText(moment(sampleMessage.timestamp).calendar());
     renderData.getByTestId('second-spacer');
     renderData.getByText(sampleMessage.messageContent);

--- a/frontend/src/components/Chat/SingleMessage.tsx
+++ b/frontend/src/components/Chat/SingleMessage.tsx
@@ -8,7 +8,7 @@ interface SingleMessageProps {
   myPlayerID: string;
 }
 export default function SingleMessage({ message, myPlayerID }: SingleMessageProps): JSX.Element {
-  const { userId, userName, messageContent, timestamp } = message;
+  const { userId, fromUserName, messageContent, timestamp } = message;
   const formattedTimestamp = moment(timestamp).calendar();
   const isSentFromUs = userId === myPlayerID;
   const className = isSentFromUs ? 'sent-from-us' : 'sent-from-them';
@@ -19,7 +19,7 @@ export default function SingleMessage({ message, myPlayerID }: SingleMessageProp
       {isSentFromUs && <div data-testid='first-spacer' className='spacer first-spacer' />}
       <div className='message-content'>
         <div className='message-details'>
-          <div className='message-username'>{userName}#{lastFourDigits}</div>
+          <div className='message-username'>{fromUserName}#{lastFourDigits}</div>
           <div className='message-timestamp'>{formattedTimestamp}</div>
         </div>
         {messageContent}

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -178,11 +178,13 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
           if (update.message.directMessageId) {
             directMessageChainToUpdate =
               nextState.directMessageChains[update.message.directMessageId];
-            directMessageChainToUpdate
-              ? directMessageChainToUpdate.addMessage(update.message)
-              : (nextState.directMessageChains[update.message.directMessageId] = new MessageChain(
-                  update.message,
-                ));
+            if (directMessageChainToUpdate) {
+              directMessageChainToUpdate.addMessage(update.message);
+            } else {
+              nextState.directMessageChains[update.message.directMessageId] = new MessageChain(
+                update.message,
+              );
+            }
           }
           break;
       }

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -169,38 +169,32 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
     case 'messageReceived':
       switch (update.message.type) {
         case MessageType.TownMessage:
-          nextState.townMessageChain = nextState.townMessageChain.addMessage(update.message);
+          nextState.townMessageChain.addMessage(update.message);
           break;
         case MessageType.ProximityMessage:
-          nextState.proximityMessageChain = nextState.proximityMessageChain.addMessage(
-            update.message,
-          );
+          nextState.proximityMessageChain.addMessage(update.message);
           break;
         default:
           if (update.message.directMessageId) {
             directMessageChainToUpdate =
               nextState.directMessageChains[update.message.directMessageId];
-            nextState.directMessageChains[
-              update.message.directMessageId
-            ] = directMessageChainToUpdate
+            directMessageChainToUpdate
               ? directMessageChainToUpdate.addMessage(update.message)
-              : new MessageChain(update.message);
+              : (nextState.directMessageChains[update.message.directMessageId] = new MessageChain(
+                  update.message,
+                ));
           }
           break;
       }
       break;
     case 'resetUnviewedMessages':
       if (update.messageType === MessageType.TownMessage) {
-        nextState.townMessageChain = nextState.townMessageChain.resetNumberUnviewed();
+        nextState.townMessageChain.resetNumberUnviewed();
       } else if (update.messageType === MessageType.ProximityMessage) {
-        nextState.proximityMessageChain = nextState.proximityMessageChain.resetNumberUnviewed();
+        nextState.proximityMessageChain.resetNumberUnviewed();
       } else if (update.directMessageId) {
         directMessageChainToUpdate = nextState.directMessageChains[update.directMessageId];
-        if (directMessageChainToUpdate) {
-          nextState.directMessageChains[
-            update.directMessageId
-          ] = directMessageChainToUpdate.resetNumberUnviewed();
-        }
+        if (directMessageChainToUpdate) directMessageChainToUpdate.resetNumberUnviewed();
       }
       break;
     default:

--- a/services/roomService/src/CoveyTypes.ts
+++ b/services/roomService/src/CoveyTypes.ts
@@ -16,7 +16,9 @@ export enum MessageType {
 export type Message = {
   // user who sent the message
   userId: string;
-  userName: string;
+  fromUserName: string;
+  // null for cases of Proximity and Town Message
+  toUserName: string | null;
   location: UserLocation;
   messageContent: string;
   timestamp: number;

--- a/services/roomService/src/client/TestUtils.ts
+++ b/services/roomService/src/client/TestUtils.ts
@@ -142,7 +142,8 @@ export function createMessageForTesting(
 export function createDirectMessageForTesting(player1ID: string, player2ID: string): Message {
   const timestamp = Date.now();
   return {
-    userName: nanoid(),
+    fromUserName: nanoid(),
+    toUserName: nanoid(),
     userId: player1ID,
     location: { x: 1, y: 2, rotation: 'front', moving: false },
     messageContent: "Omg I'm a test",

--- a/services/roomService/src/client/TestUtils.ts
+++ b/services/roomService/src/client/TestUtils.ts
@@ -117,7 +117,8 @@ export function createMessageForTesting(
   const timestamp = Date.now();
   if (type === MessageType.ProximityMessage) {
     return {
-      userName: nanoid(),
+      fromUserName: nanoid(),
+      toUserName: null,
       userId: player1.id,
       location: player1.location,
       messageContent: "Omg I'm a test",
@@ -127,7 +128,8 @@ export function createMessageForTesting(
     };
   }
   return {
-    userName: nanoid(),
+    fromUserName: nanoid(),
+    toUserName: null,
     userId: player1.id,
     location: { x: 1, y: 2, rotation: 'front', moving: false },
     messageContent: "Omg I'm a test",

--- a/services/roomService/src/lib/CoveyTownController.ts
+++ b/services/roomService/src/lib/CoveyTownController.ts
@@ -135,6 +135,7 @@ export default class CoveyTownController {
     let nearbyListeners;
     switch (message.type) {
       case MessageType.TownMessage:
+        
         this._listeners.forEach(listener => listener.onMessageReceived(message));
         break;
       case MessageType.ProximityMessage:
@@ -150,6 +151,10 @@ export default class CoveyTownController {
       default:
         break;
     }
+  }
+
+  getPlayerById(id: string) {
+    this._players.find(player => player.id === id);
   }
 
   /**

--- a/services/roomService/src/lib/CoveyTownController.ts
+++ b/services/roomService/src/lib/CoveyTownController.ts
@@ -153,10 +153,6 @@ export default class CoveyTownController {
     }
   }
 
-  getPlayerById(id: string) {
-    this._players.find(player => player.id === id);
-  }
-
   /**
    * Subscribe to events from this town. Callers should make sure to
    * unsubscribe when they no longer want those events by calling removeTownListener


### PR DESCRIPTION
We need the usernames of all players in a direct message chain, not just their ids. This is because, when a player disconnects, their username can no longer be looked up, and we want to allow DMs to persist for the remaining player once one player leaves.

The `participants` list in `MessageChain` is now represented by a list of objects in the form `{userName, userId}`. Messages now have a `toUserName` field. The first time a message in a `DirectMessageChain` is sent (in the `ChatInput` component), the `toUserName` is found by looking up the player that matches the ID in `directMessageID` that does not belong to the sending player. This username is then stored within the `DirectMessageChain`'s `participants` list, so that it can be quickly accessed in the future without looking through all the players in the town.

In hindsight, it might've been better architecturally to send four fields over in each message: `toUserName`, `fromUserName`, `toUserId` and `fromUserId`. Unfortunately, we didn't realize that we would need `toUserName` until our `directMessageId` system became fairly entrenched in our architecture--we thought we only needed the IDs of the relevant players and the username of the sender. We originally wanted to avoid including the username of the recipient to make our system more generalizable to group messages, but that sadly isn't possible while the system lacks persistence. 