### PR TITLE
fix: prevent adding duplicate messages

### DIFF
--- a/frontend/src/TestUtils.ts
+++ b/frontend/src/TestUtils.ts
@@ -5,8 +5,8 @@ export function createMessageForTesting(
   type: MessageType,
   player1Id: string,
   player2Id?: string,
+  timestamp?: number,
 ): Message {
-  const timestamp = Date.now();
   let directMessageID = null;
   let toUserName = null;
   if (player2Id) {
@@ -19,7 +19,7 @@ export function createMessageForTesting(
     userId: player1Id,
     location: { x: 1, y: 2, rotation: 'front', moving: false },
     messageContent: "Omg I'm a test",
-    timestamp,
+    timestamp: timestamp || Date.now(),
     type,
     directMessageId: directMessageID,
   };

--- a/frontend/src/classes/MessageChain.test.ts
+++ b/frontend/src/classes/MessageChain.test.ts
@@ -77,5 +77,26 @@ describe('MessageChain', () => {
       testChain.addMessage(secondMessage);
       expect(testChain.messages.length).toBe(1);
     });
+    it('should not allow for duplicate message to be added to MessageChain', () => {
+      const player1Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      testChain.addMessage(secondMessage);
+      expect(testChain.messages.length).toBe(2);
+      expect(secondMessage).toBe(testChain.messages[1]);
+      testChain.addMessage(firstMessage);
+      expect(testChain.messages.length).toBe(2);
+      expect(secondMessage).toBe(testChain.messages[1]);
+    });
+    it('should not allow for duplicate message to be added to MessageChain', () => {
+      const player1Id = nanoid();
+      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      testChain.addMessage(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+    });
   });
 });

--- a/frontend/src/classes/MessageChain.test.ts
+++ b/frontend/src/classes/MessageChain.test.ts
@@ -46,14 +46,16 @@ describe('MessageChain', () => {
       const player1Id = nanoid();
       const player2Id = nanoid();
       const firstMessage = createMessageForTesting(MessageType.DirectMessage, player1Id, player2Id);
-      firstMessage.fromUserName = 'testFromUser'
-      firstMessage.toUserName = 'testToUser'
+      firstMessage.fromUserName = 'testFromUser';
+      firstMessage.toUserName = 'testToUser';
       const testChain = createMessageChainForTesting(firstMessage);
       expect(testChain.participants?.length).toBe(2);
-      expect(testChain.participants).toEqual(expect.arrayContaining([
-        expect.objectContaining({ userName: firstMessage.fromUserName, userId: player1Id }),
-        expect.objectContaining({ userName: firstMessage.toUserName, userId: player2Id }),
-      ]))
+      expect(testChain.participants).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ userName: firstMessage.fromUserName, userId: player1Id }),
+          expect.objectContaining({ userName: firstMessage.toUserName, userId: player2Id }),
+        ]),
+      );
     });
   });
   describe('addMessage', () => {
@@ -77,18 +79,26 @@ describe('MessageChain', () => {
       testChain.addMessage(secondMessage);
       expect(testChain.messages.length).toBe(1);
     });
-    it('should not allow for duplicate message to be added to MessageChain', () => {
+    it('should allow for messages sent at same time to be added to MessageChain if each from different player', () => {
       const player1Id = nanoid();
-      const firstMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const player2Id = nanoid();
+      const timestamp = Date.now();
+      const firstMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+        timestamp,
+      );
       const testChain = createMessageChainForTesting(firstMessage);
       expect(testChain.messages.length).toBe(1);
-      const secondMessage = createMessageForTesting(MessageType.ProximityMessage, player1Id);
+      const secondMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player2Id,
+        player1Id,
+        timestamp,
+      );
       testChain.addMessage(secondMessage);
       expect(testChain.messages.length).toBe(2);
-      expect(secondMessage).toBe(testChain.messages[1]);
-      testChain.addMessage(firstMessage);
-      expect(testChain.messages.length).toBe(2);
-      expect(secondMessage).toBe(testChain.messages[1]);
     });
     it('should not allow for duplicate message to be added to MessageChain', () => {
       const player1Id = nanoid();
@@ -97,6 +107,30 @@ describe('MessageChain', () => {
       expect(testChain.messages.length).toBe(1);
       testChain.addMessage(firstMessage);
       expect(testChain.messages.length).toBe(1);
+    });
+
+    it('should not check for duplicates past older timestamps', () => {
+      const player1Id = nanoid();
+      const player2Id = nanoid();
+      const timestamp = Date.now();
+      const timestampOlder = Date.now() - 1;
+      const firstMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player1Id,
+        player2Id,
+        timestamp,
+      );
+      const testChain = createMessageChainForTesting(firstMessage);
+      expect(testChain.messages.length).toBe(1);
+      const secondMessage = createMessageForTesting(
+        MessageType.DirectMessage,
+        player2Id,
+        player1Id,
+        timestampOlder,
+      );
+      testChain.addMessage(secondMessage);
+      testChain.addMessage(firstMessage);
+      expect(testChain.messages.length).toBe(3);
     });
   });
 });

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -106,7 +106,7 @@ export default class MessageChain {
   }
 
   isDuplicateMessage(newMessage: Message): boolean {
-    for (let i = this._messages.length - 1; i >= 0; i--) {
+    for (let i = this._messages.length - 1; i >= 0; i = i - 1) {
       const messageToCheck = this._messages[i];
       if (messageToCheck.timestamp < newMessage.timestamp) {
         return false;

--- a/frontend/src/classes/MessageChain.ts
+++ b/frontend/src/classes/MessageChain.ts
@@ -12,7 +12,7 @@ function createParticipants(
   fromUserName: string,
   toUserName: string,
 ): DirectMessageParticipant[] {
-  const participantIds = directMessageId.split(':')
+  const participantIds = directMessageId.split(':');
   const toId = participantIds.filter(id => id !== fromId)[0];
   const fromParticipant = { userName: fromUserName, userId: fromId };
   const toParticipant = { userName: toUserName, userId: toId };
@@ -56,7 +56,12 @@ export default class MessageChain {
     this._isActive = true;
     if (message && message.directMessageId && message.toUserName) {
       this._directMessageId = message.directMessageId;
-      this._participants = createParticipants(message.directMessageId, message.userId, message.fromUserName, message.toUserName);
+      this._participants = createParticipants(
+        message.directMessageId,
+        message.userId,
+        message.fromUserName,
+        message.toUserName,
+      );
       this._messages.push(message);
       this._numberUnviewed = 1;
     } else {
@@ -92,13 +97,28 @@ export default class MessageChain {
    * Adds new message to this message chain.
    * @param newMessage The new message to add to this chain
    */
-  addMessage(newMessage: Message): MessageChain {
-    if (this._isActive) {
+  addMessage(newMessage: Message):MessageChain {
+    if (this._isActive && !this.isDuplicateMessage(newMessage)) {
       this._messages.push(newMessage);
       this._numberUnviewed += 1;
     }
-
     return this;
+  }
+
+  isDuplicateMessage(newMessage: Message): boolean {
+    for (let i = this._messages.length - 1; i >= 0; i--) {
+      const messageToCheck = this._messages[i];
+      if (messageToCheck.timestamp < newMessage.timestamp) {
+        return false;
+      }
+      if (
+        newMessage.timestamp === messageToCheck.timestamp &&
+        messageToCheck.fromUserName === newMessage.fromUserName
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -178,11 +178,13 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
           if (update.message.directMessageId) {
             directMessageChainToUpdate =
               nextState.directMessageChains[update.message.directMessageId];
-            directMessageChainToUpdate
-              ? directMessageChainToUpdate.addMessage(update.message)
-              : (nextState.directMessageChains[update.message.directMessageId] = new MessageChain(
-                  update.message,
-                ));
+            if (directMessageChainToUpdate) {
+              directMessageChainToUpdate.addMessage(update.message);
+            } else {
+              nextState.directMessageChains[update.message.directMessageId] = new MessageChain(
+                update.message,
+              );
+            }
           }
           break;
       }

--- a/frontend/src/reducer.ts
+++ b/frontend/src/reducer.ts
@@ -169,38 +169,32 @@ export function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): C
     case 'messageReceived':
       switch (update.message.type) {
         case MessageType.TownMessage:
-          nextState.townMessageChain = nextState.townMessageChain.addMessage(update.message);
+          nextState.townMessageChain.addMessage(update.message);
           break;
         case MessageType.ProximityMessage:
-          nextState.proximityMessageChain = nextState.proximityMessageChain.addMessage(
-            update.message,
-          );
+          nextState.proximityMessageChain.addMessage(update.message);
           break;
         default:
           if (update.message.directMessageId) {
             directMessageChainToUpdate =
               nextState.directMessageChains[update.message.directMessageId];
-            nextState.directMessageChains[
-              update.message.directMessageId
-            ] = directMessageChainToUpdate
+            directMessageChainToUpdate
               ? directMessageChainToUpdate.addMessage(update.message)
-              : new MessageChain(update.message);
+              : (nextState.directMessageChains[update.message.directMessageId] = new MessageChain(
+                  update.message,
+                ));
           }
           break;
       }
       break;
     case 'resetUnviewedMessages':
       if (update.messageType === MessageType.TownMessage) {
-        nextState.townMessageChain = nextState.townMessageChain.resetNumberUnviewed();
+        nextState.townMessageChain.resetNumberUnviewed();
       } else if (update.messageType === MessageType.ProximityMessage) {
-        nextState.proximityMessageChain = nextState.proximityMessageChain.resetNumberUnviewed();
+        nextState.proximityMessageChain.resetNumberUnviewed();
       } else if (update.directMessageId) {
         directMessageChainToUpdate = nextState.directMessageChains[update.directMessageId];
-        if (directMessageChainToUpdate) {
-          nextState.directMessageChains[
-            update.directMessageId
-          ] = directMessageChainToUpdate.resetNumberUnviewed();
-        }
+        if (directMessageChainToUpdate) directMessageChainToUpdate.resetNumberUnviewed();
       }
       break;
     default:


### PR DESCRIPTION
provides a bandaid fix that prevents a message from being added to a chain if it already exists in the chain. The timestamp and the `fromUserName` are used to determine whether the message is duplicated. We iterate through the array of messages when every message is added, but short circuit once we reach a timestamp older than the one we're checking for—since all messages should be sorted by timestamp. 