### PR TITLE
front end behavior for player disconnecting -> direct messages

### DIFF
--- a/frontend/src/components/Chat/ChatContainer.css
+++ b/frontend/src/components/Chat/ChatContainer.css
@@ -15,7 +15,7 @@ the height of the viewport */
   border-top: 1px solid #ddd;
 }
 
-.inactive {
+.chat-container .inactive {
   font-weight: bold;
   border-top: 1px solid lightblue;
   height: 100px;

--- a/frontend/src/components/Chat/ChatContainer.css
+++ b/frontend/src/components/Chat/ChatContainer.css
@@ -14,3 +14,13 @@ the height of the viewport */
   width: 100%;
   border-top: 1px solid #ddd;
 }
+
+.inactive {
+  font-weight: bold;
+  border-top: 1px solid lightblue;
+  height: 100px;
+  width: 100%;
+  font-size: 0.8em;
+  text-align: center;
+  padding: 20px;
+}

--- a/frontend/src/components/Chat/ChatContainer.tsx
+++ b/frontend/src/components/Chat/ChatContainer.tsx
@@ -40,6 +40,7 @@ export default function ChatContainer({
 
   const messageChain = getMessageChain();
   const messageChainNumberUnviewed = messageChain ? messageChain.numberUnviewed : 0;
+  const disabledMessage = messageChain?.isActive ? '' : 'You can no longer message with this player, as they have disconnected.';
 
   useEffect(() => {
     if (messageChainNumberUnviewed) {
@@ -73,6 +74,7 @@ export default function ChatContainer({
           <SingleMessage key={message.timestamp} message={message} myPlayerID={myPlayerID} />
         ))}
       </div>
+      <div>{disabledMessage}</div>
       <div className='chat-input'>
         <ChatInput
           messageType={chainType}

--- a/frontend/src/components/Chat/ChatContainer.tsx
+++ b/frontend/src/components/Chat/ChatContainer.tsx
@@ -40,7 +40,6 @@ export default function ChatContainer({
 
   const messageChain = getMessageChain();
   const messageChainNumberUnviewed = messageChain ? messageChain.numberUnviewed : 0;
-  const disabledMessage = messageChain?.isActive ? '' : 'You can no longer message with this player, as they have disconnected.';
 
   useEffect(() => {
     if (messageChainNumberUnviewed) {
@@ -67,6 +66,18 @@ export default function ChatContainer({
       </div>
     );
   }
+
+  const chatInput = <div className='chat-input'>
+    <ChatInput
+      messageType={chainType}
+      directMessageId={directMessageID}
+      isDisabled={!messageChain.isActive}
+    />
+  </div>
+
+  const disabledMessage = 'You can no longer message with this player, as they have disconnected.';
+
+
   return (
     <div className='chat-container'>
       <div id='scrollable-messages' className='scrollable-messages'>
@@ -74,13 +85,8 @@ export default function ChatContainer({
           <SingleMessage key={message.timestamp} message={message} myPlayerID={myPlayerID} />
         ))}
       </div>
-      <div>{disabledMessage}</div>
-      <div className='chat-input'>
-        <ChatInput
-          messageType={chainType}
-          directMessageId={directMessageID}
-          isDisabled={!messageChain.isActive}
-        />
+      <div className={`${messageChain.isActive ? 'active' : 'inactive'}`}>
+        {messageChain.isActive ? chatInput : disabledMessage}
       </div>
     </div>
   );

--- a/frontend/src/components/Chat/ChatContainer.tsx
+++ b/frontend/src/components/Chat/ChatContainer.tsx
@@ -60,7 +60,6 @@ export default function ChatContainer({
           <ChatInput
             messageType={chainType}
             directMessageId={directMessageID}
-            isDisabled={undefined}
           />
         </div>
       </div>
@@ -71,7 +70,6 @@ export default function ChatContainer({
     <ChatInput
       messageType={chainType}
       directMessageId={directMessageID}
-      isDisabled={!messageChain.isActive}
     />
   </div>
 

--- a/frontend/src/components/Chat/ChatContainer.tsx
+++ b/frontend/src/components/Chat/ChatContainer.tsx
@@ -77,7 +77,7 @@ export default function ChatContainer({
         <ChatInput
           messageType={chainType}
           directMessageId={directMessageID}
-          isDisabled={undefined}
+          isDisabled={!messageChain.isActive}
         />
       </div>
     </div>

--- a/frontend/src/components/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/Chat/ChatInput.test.tsx
@@ -57,7 +57,6 @@ function wrappedChatInput(isDisabled = false, directMessageChains = {}, players 
         <ChatInput
           messageType={MessageType.DirectMessage}
           directMessageId='123:321'
-          isDisabled={isDisabled}
         />
       </CoveyAppContext.Provider>
     </ChakraProvider>

--- a/frontend/src/components/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/Chat/ChatInput.test.tsx
@@ -78,15 +78,6 @@ describe('ChatInput', () => {
     if (sendButton) expect(sendButton.disabled).toBeTruthy();
     if (textArea) expect(textArea.disabled).toBeFalsy();
   });
-  it('renders a disabled textarea and a disabled button if isDisabled prop is true', () => {
-    const renderData = render(wrappedChatInput(true));
-    const textArea = renderData.getByPlaceholderText('Send a message...').closest('textarea');
-    const sendButton = renderData.getByText('Send').closest('button');
-    expect(sendButton).toBeTruthy();
-    expect(textArea).toBeTruthy();
-    if (sendButton) expect(sendButton.disabled).toBeTruthy();
-    if (textArea) expect(textArea.disabled).toBeTruthy();
-  });
   it('enables send button when user begins to type', () => {
     const renderData = render(wrappedChatInput());
     fireEvent.change(renderData.getByPlaceholderText('Send a message...'), {

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -128,7 +128,6 @@ function ChatInput({ messageType, directMessageId }: ChatInputProps): JSX.Elemen
             placeholder='Send a message...'
             borderRadius='0'
             className='text-area'
-            disabled={false}
           />
         </div>
         <div className='button'>

--- a/frontend/src/components/Chat/ChatInput.tsx
+++ b/frontend/src/components/Chat/ChatInput.tsx
@@ -9,11 +9,10 @@ import './ChatInput.css';
 interface ChatInputProps {
   messageType: MessageType;
   directMessageId: string | null;
-  isDisabled: boolean | undefined;
 }
 
 // an input for sending messages from frontend to the socket
-function ChatInput({ messageType, directMessageId, isDisabled }: ChatInputProps): JSX.Element {
+function ChatInput({ messageType, directMessageId }: ChatInputProps): JSX.Element {
   const [messageContent, setMessageContent] = useState<string>('');
   const {
     myPlayerID,
@@ -129,7 +128,7 @@ function ChatInput({ messageType, directMessageId, isDisabled }: ChatInputProps)
             placeholder='Send a message...'
             borderRadius='0'
             className='text-area'
-            disabled={isDisabled}
+            disabled={false}
           />
         </div>
         <div className='button'>
@@ -137,7 +136,7 @@ function ChatInput({ messageType, directMessageId, isDisabled }: ChatInputProps)
             bg='lightblue'
             borderRadius='0'
             height='100px'
-            disabled={isDisabled || !canSendMessage}
+            disabled={!canSendMessage}
             type='submit'>
             Send
           </Button>

--- a/frontend/src/components/Chat/DirectMessageSelect.tsx
+++ b/frontend/src/components/Chat/DirectMessageSelect.tsx
@@ -18,18 +18,19 @@ export default function DirectMessageSelect({
   const [chosenDirectID, setDirectID] = useState<string>('');
 
   const chattedWithPlayers: string[] = [];
-  const playersWithChats: DirectMessageParticipant[] = [];
+  const participantsWithChats: DirectMessageParticipant[] = [];
 
-  Object.values(directMessageChains).forEach(value => {
-    if (value.participants) {
-      const otherPlayer = value.participants.filter(
+  Object.values(directMessageChains).forEach(chain => {
+    // our MessageChain type only has participants when it contains DirectmEssage
+    if (chain.participants) {
+      const otherPlayer = chain.participants.filter(
         participant => participant.userId !== myPlayerID,
       )[0];
-      playersWithChats.push(otherPlayer);
+      participantsWithChats.push(otherPlayer);
       chattedWithPlayers.push(otherPlayer.userId);
     }
   });
-  playersWithChats.sort((a, b) => a.userName.localeCompare(b.userName));
+  participantsWithChats.sort((a, b) => a.userName.localeCompare(b.userName));
 
   // don't want to direct chat with self
   chattedWithPlayers.push(myPlayerID);
@@ -78,7 +79,7 @@ export default function DirectMessageSelect({
             </Tr>
           </Thead>
           <Tbody>
-            {playersWithChats.map(participant => {
+            {participantsWithChats.map(participant => {
               const userName = `${participant.userName}#${participant.userId.slice(-4)}`;
               return (
                 <Tr key={participant.userId}>

--- a/frontend/src/components/Chat/DirectMessageSelect.tsx
+++ b/frontend/src/components/Chat/DirectMessageSelect.tsx
@@ -16,20 +16,26 @@ export default function DirectMessageSelect({
 }: DirectMessageSelectProps): JSX.Element {
   const { myPlayerID, players, directMessageChains } = useCoveyAppState();
   const [chosenDirectID, setDirectID] = useState<string>('');
-  
-  const chattedWithPlayers: String[] = [];
+
+  const chattedWithPlayers: string[] = [];
   const playersWithChats: DirectMessageParticipant[] = [];
-  for (let key in directMessageChains) {
-    let value = directMessageChains[key];
+
+  Object.values(directMessageChains).forEach(value => {
     if (value.participants) {
-      const otherPlayer = value.participants.filter((participant) => participant.userId !== myPlayerID)[0];
+      const otherPlayer = value.participants.filter(
+        participant => participant.userId !== myPlayerID,
+      )[0];
       playersWithChats.push(otherPlayer);
       chattedWithPlayers.push(otherPlayer.userId);
     }
-  }
+  });
 
-  const playersWithoutChats = players.filter((playerToCheck) => !chattedWithPlayers.includes(playerToCheck.id));
+  // don't want to direct chat with self
+  chattedWithPlayers.push(myPlayerID);
 
+  const playersWithoutChats = players.filter(
+    playerToCheck => !chattedWithPlayers.includes(playerToCheck.id),
+  );
 
   const handleChat = async (otherPlayerID: string, userName: string) => {
     const directMessageId = [myPlayerID, otherPlayerID].sort().join(':');
@@ -71,22 +77,22 @@ export default function DirectMessageSelect({
             </Tr>
           </Thead>
           <Tbody>
-            {playersWithChats.map(participant => (
-              <Tr key={participant.userId}>
-                <Td role='cell'>
-                  {participant.userName}#{participant.userId.slice(-4)}
-                  {renderNotification(participant)}
-                </Td>
-                <Td role='cell'>
-                  <Button
-                    onClick={() =>
-                      handleChat(participant.userName, `${participant.userName}#${participant.userId.slice(-4)}`)
-                    }>
-                    Continue Chat
-                  </Button>
-                </Td>
-              </Tr>
-            ))}
+            {playersWithChats.map(participant => {
+              const userName = `${participant.userName}#${participant.userId.slice(-4)}`;
+              return (
+                <Tr key={participant.userId}>
+                  <Td role='cell'>
+                    {participant.userName}#{participant.userId.slice(-4)}
+                    {renderNotification(participant)}
+                  </Td>
+                  <Td role='cell'>
+                    <Button onClick={() => handleChat(participant.userId, userName)}>
+                      Continue Chat
+                    </Button>
+                  </Td>
+                </Tr>
+              );
+            })}
           </Tbody>
         </Table>
       </Box>

--- a/frontend/src/components/Chat/DirectMessageSelect.tsx
+++ b/frontend/src/components/Chat/DirectMessageSelect.tsx
@@ -112,7 +112,7 @@ export default function DirectMessageSelect({
               return (
                 <Tr key={player.id}>
                   <Td role='cell'>
-                    {player.userName} #{player.id.slice(-4)}
+                    {player.userName}#{player.id.slice(-4)}
                   </Td>
                   <Td role='cell'>
                     <Button onClick={() => handleChat(player.id, userName)}>Chat</Button>

--- a/frontend/src/components/Chat/DirectMessageSelect.tsx
+++ b/frontend/src/components/Chat/DirectMessageSelect.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Heading, Table, Tag, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import { MessageType } from '../../classes/MessageChain';
-import Player from '../../classes/Player';
+import { DirectMessageParticipant, MessageType } from '../../classes/MessageChain';
 import useCoveyAppState from '../../hooks/useCoveyAppState';
 import ChatContainer from './ChatContainer';
 
@@ -17,17 +16,20 @@ export default function DirectMessageSelect({
 }: DirectMessageSelectProps): JSX.Element {
   const { myPlayerID, players, directMessageChains } = useCoveyAppState();
   const [chosenDirectID, setDirectID] = useState<string>('');
-  const playersWithChats: Player[] = [];
-  const playersWithoutChats: Player[] = [];
-
-  players.forEach(player => {
-    const directMessageId = [myPlayerID, player.id].sort().join(':');
-    if (directMessageChains[directMessageId]) {
-      playersWithChats.push(player);
-    } else if (player.id !== myPlayerID) {
-      playersWithoutChats.push(player);
+  
+  const chattedWithPlayers: String[] = [];
+  const playersWithChats: DirectMessageParticipant[] = [];
+  for (let key in directMessageChains) {
+    let value = directMessageChains[key];
+    if (value.participants) {
+      const otherPlayer = value.participants.filter((participant) => participant.userId !== myPlayerID)[0];
+      playersWithChats.push(otherPlayer);
+      chattedWithPlayers.push(otherPlayer.userId);
     }
-  });
+  }
+
+  const playersWithoutChats = players.filter((playerToCheck) => !chattedWithPlayers.includes(playerToCheck.id));
+
 
   const handleChat = async (otherPlayerID: string, userName: string) => {
     const directMessageId = [myPlayerID, otherPlayerID].sort().join(':');
@@ -36,8 +38,8 @@ export default function DirectMessageSelect({
     onDirectChatOpen(userName);
   };
 
-  const renderNotification = (player: Player): JSX.Element | null => {
-    const directMessageId = [player.id, myPlayerID].sort().join(':');
+  const renderNotification = (participant: DirectMessageParticipant): JSX.Element | null => {
+    const directMessageId = [participant.userId, myPlayerID].sort().join(':');
     const messageChain = directMessageChains[directMessageId];
     if (!messageChain) {
       return null;
@@ -69,16 +71,16 @@ export default function DirectMessageSelect({
             </Tr>
           </Thead>
           <Tbody>
-            {playersWithChats.map(player => (
-              <Tr key={player.id}>
+            {playersWithChats.map(participant => (
+              <Tr key={participant.userId}>
                 <Td role='cell'>
-                  {player.userName}#{player.id.slice(-4)}
-                  {renderNotification(player)}
+                  {participant.userName}#{participant.userId.slice(-4)}
+                  {renderNotification(participant)}
                 </Td>
                 <Td role='cell'>
                   <Button
                     onClick={() =>
-                      handleChat(player.id, `${player.userName}#${player.id.slice(-4)}`)
+                      handleChat(participant.userName, `${participant.userName}#${participant.userId.slice(-4)}`)
                     }>
                     Continue Chat
                   </Button>

--- a/frontend/src/components/Chat/DirectMessageSelect.tsx
+++ b/frontend/src/components/Chat/DirectMessageSelect.tsx
@@ -29,13 +29,14 @@ export default function DirectMessageSelect({
       chattedWithPlayers.push(otherPlayer.userId);
     }
   });
+  playersWithChats.sort((a, b) => a.userName.localeCompare(b.userName));
 
   // don't want to direct chat with self
   chattedWithPlayers.push(myPlayerID);
 
   const playersWithoutChats = players.filter(
     playerToCheck => !chattedWithPlayers.includes(playerToCheck.id),
-  );
+  ).sort((a, b) => a.userName.localeCompare(b.userName));
 
   const handleChat = async (otherPlayerID: string, userName: string) => {
     const directMessageId = [myPlayerID, otherPlayerID].sort().join(':');

--- a/frontend/src/components/Chat/DirectMessageSelect.tsx
+++ b/frontend/src/components/Chat/DirectMessageSelect.tsx
@@ -86,9 +86,7 @@ export default function DirectMessageSelect({
                     {renderNotification(participant)}
                   </Td>
                   <Td role='cell'>
-                    <Button onClick={() => handleChat(participant.userId, userName)}>
-                      Continue Chat
-                    </Button>
+                    <Button onClick={() => handleChat(participant.userId, userName)}>Chat</Button>
                   </Td>
                 </Tr>
               );
@@ -116,7 +114,7 @@ export default function DirectMessageSelect({
                     {player.userName} #{player.id.slice(-4)}
                   </Td>
                   <Td role='cell'>
-                    <Button onClick={() => handleChat(player.id, userName)}>Start Chat</Button>
+                    <Button onClick={() => handleChat(player.id, userName)}>Chat</Button>
                   </Td>
                 </Tr>
               );


### PR DESCRIPTION
changes to DirectMessageSelect:
- able to view started conversations with disconnected players
- modify renderNotification to take in a DirectMessageParticipant
- organized alphabetically in each section (Continue and Start tables)
- changed buttons to "Chat"

changes to ChatContainer: 
- conditional rendering of ChatInput vs note to user

![Screen Shot 2021-04-08 at 10 55 10 AM](https://user-images.githubusercontent.com/49101279/114060167-1798b480-9863-11eb-8dd3-3877c29943cf.png)
