### PR TITLE
tiny scrolling css fix

### DIFF
--- a/frontend/src/components/Chat/ChatSidebar.tsx
+++ b/frontend/src/components/Chat/ChatSidebar.tsx
@@ -145,7 +145,7 @@ export default function ChatSidebar(): JSX.Element {
           </TabList>
           <TabPanels>
             <TabPanel padding='0'>
-              <div className='scrollable-select'>
+              <div className={isViewingDirectChatContainer ? undefined : 'scrollable-select'}>
                 <DirectMessageSelect
                   setIsViewingChatContainer={setIsViewingDirectChatContainer}
                   isViewingChatContainer={isViewingDirectChatContainer}


### PR DESCRIPTION
this is a one line css change meant to correct some unexpected scrolling behavior in the direct message select, basically we don't want the select itself to be scrollable when the chat container already is